### PR TITLE
Refactor/status bar panels style

### DIFF
--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/CalendarWidget.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/CalendarWidget.qml
@@ -314,6 +314,10 @@ Item {
                             StyledToolTip {
                                 visible: hasEvent && !eventPopup.visible
                                 text: {
+                                    const m = root.viewingDate.getMonth() + 1
+                                    const y = root.viewingDate.getFullYear()
+                                    const mm = String(m).padStart(2, '0')
+                                    const dd = String(cell.day).padStart(2, '0')
                                     const evs = root.getEventsForDate(y + "-" + mm + "-" + dd)
                                     return evs.map(e => {
                                         let s = e.title + (e.time ? " (" + e.time + (e.endTime ? " - " + e.endTime : "") + ")" : "")

--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/CalendarWidget.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/CalendarWidget.qml
@@ -150,7 +150,12 @@ Item {
                             Layout.fillWidth: true
                         }
                         StyledText {
-                            text: modelData.time + (modelData.recurrence !== "once" ? " · " + modelData.recurrence : "")
+                            text: {
+                                let t = modelData.time
+                                if (modelData.endTime) t += " - " + modelData.endTime
+                                if (modelData.recurrence !== "once") t += " · " + modelData.recurrence
+                                return t
+                            }
                             font.pixelSize: Appearance.font.pixelSize.smaller
                             color: Appearance.colors.colSubtext
                         }
@@ -304,6 +309,17 @@ Item {
                                 eventPopup.dateStr = dateStr
                                 eventPopup.events = root.getEventsForDate(dateStr)
                                 eventPopup.visible = !eventPopup.visible
+                            }
+
+                            StyledToolTip {
+                                visible: hasEvent && !eventPopup.visible
+                                text: {
+                                    const evs = root.getEventsForDate(y + "-" + mm + "-" + dd)
+                                    return evs.map(e => {
+                                        let s = e.title + (e.time ? " (" + e.time + (e.endTime ? " - " + e.endTime : "") + ")" : "")
+                                        return s
+                                    }).join("\n")
+                                }
                             }
                         }
                     }

--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashCalendar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashCalendar.qml
@@ -14,24 +14,28 @@ RowLayout {
 
     // Load schedule to mark days on the calendar
     property var scheduledEvents: []
+    readonly property string storagePath: Directories.home.replace("file://", "") + "/.cache/nandoroid/schedule.json"
+
+    function reloadSchedule() {
+        scheduleFile.reload()
+    }
+
     FileView {
-        id: scheduleView
-        // Match the same path as DashSchedule uses
-        path: Directories.home.replace("file://", "") + "/.cache/nandoroid/schedule.json"
-        watchChanges: true
-        onLoadFailed: root.scheduledEvents = []
+        id: scheduleFile
+        path: root.storagePath
         onLoaded: {
-            try { root.scheduledEvents = JSON.parse(scheduleView.text()) } catch(e) { root.scheduledEvents = [] }
+            try {
+                let parsed = JSON.parse(scheduleFile.text())
+                if (Array.isArray(parsed)) root.scheduledEvents = parsed
+            } catch(e) {}
         }
     }
 
-    function reloadSchedule() {
-        scheduleView.reload()
-    }
+    Component.onCompleted: scheduleFile.reload()
+
     // Build a flat list of all dates this event applies to (expand recurring)
     readonly property var eventDates: {
         let dates = []
-        const today = new Date()
         for (let ev of root.scheduledEvents) {
             if (!ev.date) continue
             dates.push(ev.date)
@@ -66,7 +70,6 @@ RowLayout {
         color: Appearance.m3colors.m3surfaceContainerHigh
         radius: Appearance.rounding.normal
 
-        // Centre the calendar widget - it has a fixed inner size
         CalendarWidget {
             anchors.centerIn: parent
             width: Math.min(parent.width - 24, implicitWidth)

--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashCalendar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashCalendar.qml
@@ -91,7 +91,7 @@ RowLayout {
         ColumnLayout {
             anchors.fill: parent
             anchors.margins: 16
-            spacing: 10
+            spacing: 14
 
             // ── Circular Arc Timer ──
             Item {
@@ -201,6 +201,8 @@ RowLayout {
                         implicitHeight: 32
                         isHighlighted: PomodoroService.mode === modelData.mode
                         iconName: modelData.icon
+                        iconSize: 18
+                        spacing: 5
                         buttonText: modelData.name
                         colInactive: Appearance.m3colors.m3surfaceContainerHigh
                         onClicked: PomodoroService.setMode(modelData.mode)
@@ -222,11 +224,11 @@ RowLayout {
 
                 RippleButton {
                     id: startPill
-                    implicitWidth: 110; implicitHeight: 44; buttonRadius: 22
+                    implicitWidth: 140; implicitHeight: 44; buttonRadius: 22
                     colBackground: Appearance.m3colors.m3primary
                     onClicked: PomodoroService.active ? PomodoroService.pause() : PomodoroService.start()
                     contentItem: RowLayout {
-                        spacing: 6; Layout.alignment: Qt.AlignHCenter
+                        spacing: 8; Layout.alignment: Qt.AlignHCenter
                         MaterialSymbol {
                             text: PomodoroService.active ? "pause" : "play_arrow"
                             iconSize: 20; color: Appearance.m3colors.m3onPrimary
@@ -295,7 +297,7 @@ RowLayout {
                                 { icon: "self_improvement", name: "Long", mode: 2 }
                             ]
                             delegate: SegmentedButton {
-                                implicitWidth: 58; implicitHeight: 24
+                                implicitWidth: 72; implicitHeight: 24
                                 isHighlighted: PomodoroService.nextBreakMode === modelData.mode
                                 iconName: modelData.icon; buttonText: modelData.name; iconSize: 11
                                 colInactive: Appearance.m3colors.m3surfaceContainerHigh

--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashSchedule.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashSchedule.qml
@@ -143,24 +143,36 @@ Item {
         }
         save()
         selectedId = ""
-        clearForm()
-    }
-
-    // ── Layout ──
+       // ── Layout ──
     Row {
         id: schedRow
         anchors.fill: parent
         spacing: 12
 
         // ── Event List (fixed width) ──
-        Item {
+        ColumnLayout {
             id: schedSidebar
-            width: 210
+            width: 200
             height: parent.height
+            spacing: 8
 
-            // List (full height - “+ New Event” card is now first item in the list)
+            // New event button
+            RippleButton {
+                Layout.fillWidth: true
+                implicitHeight: 40
+                buttonRadius: 20
+                colBackground: Appearance.colors.colPrimary
+                onClicked: { root.selectedId = ""; root.clearForm() }
+                RowLayout {
+                    anchors.centerIn: parent; spacing: 6
+                    MaterialSymbol { text: "add"; iconSize: 18; color: Appearance.colors.colOnPrimary }
+                    StyledText { text: "New Event"; color: Appearance.colors.colOnPrimary; font.weight: Font.Medium }
+                }
+            }
+
             Rectangle {
-                anchors.fill: parent
+                Layout.fillWidth: true
+                Layout.fillHeight: true
                 color: Appearance.m3colors.m3surfaceContainer
                 radius: Appearance.rounding.normal
                 clip: true
@@ -170,48 +182,24 @@ Item {
                     anchors.fill: parent
                     anchors.margins: 6
                     spacing: 4
-                    // Prepend a sentinel {id:"__new__"} as the first item
-                    model: {
-                        let sorted = root.events.slice().sort((a, b) =>
+                    model: root.events.slice().sort((a, b) =>
                             (a.date + a.time).localeCompare(b.date + b.time))
-                        return [{id: "__new__", title: "+ New Event", _sentinel: true}].concat(sorted)
-                    }
 
                     delegate: Rectangle {
                         required property var modelData
-                        required property int index
                         width: eventList.width
-                        height: modelData._sentinel ? 44 : (itemCol.implicitHeight + 16)
+                        height: (itemCol.implicitHeight + 16)
                         radius: Appearance.rounding.small
 
-                        // Sentinel: “+ New Event” card
-                        visible: true
-                        color: modelData._sentinel
-                            ? (newEvMouse.containsMouse
-                                ? Qt.rgba(Appearance.colors.colPrimary.r, Appearance.colors.colPrimary.g, Appearance.colors.colPrimary.b, 0.18)
-                                : Qt.rgba(Appearance.colors.colPrimary.r, Appearance.colors.colPrimary.g, Appearance.colors.colPrimary.b, 0.10))
-                            : (root.selectedId === modelData.id
+                        color: root.selectedId === modelData.id
                                 ? Appearance.colors.colPrimaryContainer
-                                : (evMouse.containsMouse ? Appearance.colors.colLayer2 : "transparent"))
-
-                        border.color: modelData._sentinel ? Qt.rgba(Appearance.colors.colPrimary.r, Appearance.colors.colPrimary.g, Appearance.colors.colPrimary.b, 0.4) : "transparent"
-                        border.width: modelData._sentinel ? 1 : 0
+                                : (evMouse.containsMouse ? Appearance.colors.colLayer2 : "transparent")
 
                         Behavior on color { ColorAnimation { duration: 150 } }
-
-                        // “+ New Event” sentinel content
-                        RowLayout {
-                            visible: modelData._sentinel === true
-                            anchors.centerIn: parent
-                            spacing: 6
-                            MaterialSymbol { text: "add"; iconSize: 16; color: Appearance.colors.colPrimary }
-                            StyledText { text: "New Event"; color: Appearance.colors.colPrimary; font.weight: Font.Medium; font.pixelSize: Appearance.font.pixelSize.small }
-                        }
 
                         // Normal event content
                         ColumnLayout {
                             id: itemCol
-                            visible: !modelData._sentinel
                             anchors.left: parent.left
                             anchors.right: parent.right
                             anchors.verticalCenter: parent.verticalCenter
@@ -220,7 +208,7 @@ Item {
                             spacing: 2
 
                             StyledText {
-                                text: modelData._sentinel ? "" : modelData.title
+                                text: modelData.title
                                 font.pixelSize: Appearance.font.pixelSize.normal
                                 font.weight: Font.Medium
                                 color: root.selectedId === modelData.id
@@ -230,9 +218,7 @@ Item {
                                 Layout.fillWidth: true
                             }
                             StyledText {
-                                visible: !modelData._sentinel
                                 text: {
-                                    if (modelData._sentinel) return ""
                                     let d = modelData.date + " " + modelData.time
                                     if (modelData.recurrence !== "once") d += " · " + modelData.recurrence
                                     return d
@@ -243,9 +229,8 @@ Item {
                             }
                         }
 
-                        // Delete button (not for sentinel)
+                        // Delete button
                         RippleButton {
-                            visible: !modelData._sentinel
                             anchors.right: parent.right
                             anchors.rightMargin: 6
                             anchors.verticalCenter: parent.verticalCenter
@@ -255,26 +240,14 @@ Item {
                             MaterialSymbol { anchors.centerIn: parent; text: "delete"; iconSize: 16; color: Appearance.colors.colSubtext }
                         }
 
-                        // Sentinel mouse
-                        MouseArea {
-                            id: newEvMouse
-                            anchors.fill: parent
-                            visible: modelData._sentinel === true
-                            hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: { root.selectedId = ""; root.clearForm() }
-                        }
-
                         // Event mouse
                         MouseArea {
                             id: evMouse
                             anchors.fill: parent
                             anchors.rightMargin: 36
-                            visible: !modelData._sentinel
                             hoverEnabled: true
                             cursorShape: Qt.PointingHandCursor
                             onClicked: {
-                                if (modelData._sentinel) return
                                 // Temporarily disable autosave triggers while populating fields
                                 let oldSelectedId = root.selectedId
                                 root.selectedId = ""
@@ -295,7 +268,7 @@ Item {
 
         // ── Event Editor ──
         ColumnLayout {
-            width: schedRow.width - schedSidebar.width - schedRow.spacing
+            Layout.fillWidth: true
             height: parent.height
             spacing: 12
 
@@ -313,8 +286,8 @@ Item {
                 implicitHeight: 44
                 radius: Appearance.rounding.small
                 color: Appearance.m3colors.m3surfaceContainer
-                border.color: titleField.activeFocus ? Appearance.colors.colPrimary : Appearance.colors.colOutlineVariant
-                border.width: titleField.activeFocus ? 2 : 1
+                border.color: titleField.activeFocus ? Appearance.colors.colPrimary : "transparent"
+                border.width: 2
 
                 TextInput {
                     id: titleField
@@ -348,8 +321,8 @@ Item {
                     Layout.fillWidth: true; implicitHeight: 44
                     radius: Appearance.rounding.small
                     color: Appearance.m3colors.m3surfaceContainer
-                    border.color: dateField.activeFocus ? Appearance.colors.colPrimary : Appearance.colors.colOutlineVariant
-                    border.width: dateField.activeFocus ? 2 : 1
+                    border.color: dateField.activeFocus ? Appearance.colors.colPrimary : "transparent"
+                    border.width: 2
                     RowLayout {
                         anchors.fill: parent; anchors.margins: 10; spacing: 6
                         MaterialSymbol { text: "calendar_today"; iconSize: 16; color: Appearance.colors.colSubtext }
@@ -371,8 +344,8 @@ Item {
                     Layout.preferredWidth: 110; implicitHeight: 44
                     radius: Appearance.rounding.small
                     color: Appearance.m3colors.m3surfaceContainer
-                    border.color: timeField.activeFocus ? Appearance.colors.colPrimary : Appearance.colors.colOutlineVariant
-                    border.width: timeField.activeFocus ? 2 : 1
+                    border.color: timeField.activeFocus ? Appearance.colors.colPrimary : "transparent"
+                    border.width: 2
                     RowLayout {
                         anchors.fill: parent; anchors.margins: 10; spacing: 6
                         MaterialSymbol { text: "schedule"; iconSize: 16; color: Appearance.colors.colSubtext }
@@ -394,10 +367,10 @@ Item {
             Rectangle {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                radius: Appearance.rounding.small
+                radius: Appearance.rounding.normal
                 color: Appearance.m3colors.m3surfaceContainer
-                border.color: descArea.activeFocus ? Appearance.colors.colPrimary : Appearance.colors.colOutlineVariant
-                border.width: descArea.activeFocus ? 2 : 1
+                border.color: descArea.activeFocus ? Appearance.colors.colPrimary : "transparent"
+                border.width: 2
                 clip: true
 
                 TextEdit {
@@ -439,6 +412,9 @@ Item {
                             colBackground: root.formRecurrence === modelData
                                 ? Appearance.colors.colPrimary
                                 : Appearance.m3colors.m3surfaceContainer
+                            colBackgroundHover: root.formRecurrence === modelData
+                                ? Appearance.colors.colPrimary
+                                : Appearance.colors.colLayer2
                             onClicked: {
                                 root.formRecurrence = modelData
                                 if (root.selectedId) autoSaveTimer.restart()
@@ -471,6 +447,7 @@ Item {
                     StyledText { text: root.selectedId ? "Update Event" : "Add Event"; font.weight: Font.Medium; color: Appearance.colors.colOnPrimary }
                 }
             }
+        }
         }
     }
 }

--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashSchedule.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashSchedule.qml
@@ -143,8 +143,11 @@ Item {
         }
         save()
         selectedId = ""
-       // ── Layout ──
-    Row {
+        clearForm()
+    }
+
+    // ── Layout ──
+    RowLayout {
         id: schedRow
         anchors.fill: parent
         spacing: 12
@@ -152,8 +155,8 @@ Item {
         // ── Event List (fixed width) ──
         ColumnLayout {
             id: schedSidebar
-            width: 200
-            height: parent.height
+            Layout.preferredWidth: 200
+            Layout.fillHeight: true
             spacing: 8
 
             // New event button
@@ -269,7 +272,7 @@ Item {
         // ── Event Editor ──
         ColumnLayout {
             Layout.fillWidth: true
-            height: parent.height
+            Layout.fillHeight: true
             spacing: 12
 
             // Header
@@ -447,7 +450,6 @@ Item {
                     StyledText { text: root.selectedId ? "Update Event" : "Add Event"; font.weight: Font.Medium; color: Appearance.colors.colOnPrimary }
                 }
             }
-        }
         }
     }
 }

--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashSchedule.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashSchedule.qml
@@ -9,36 +9,16 @@ import Quickshell.Io
 
 /**
  * Dashboard Tab 2: Schedule / Calendar Maker
- * Local JSON storage, recurring events, desktop reminders via notify-send.
+ * Local JSON storage, recurring events.
  */
 Item {
     id: root
 
-    // ── Persistence ──
     property var events: []
-    property bool loaded: false
-
     readonly property string storagePath: Directories.home.replace("file://", "") + "/.cache/nandoroid/schedule.json"
-
-    FileView {
-        id: scheduleFile
-        path: root.storagePath
-        watchChanges: false
-        onLoaded: {
-            try {
-                let parsed = JSON.parse(scheduleFile.text())
-                if (Array.isArray(parsed)) root.events = parsed
-            } catch(e) {}
-            root.loaded = true
-        }
-    }
 
     function save() {
         scheduleFile.setText(JSON.stringify(root.events, null, 2))
-    }
-
-    function makeId() {
-        return Date.now().toString(36) + Math.random().toString(36).substr(2, 5)
     }
 
     function deleteEvent(id) {
@@ -47,66 +27,31 @@ Item {
         if (selectedId === id) { selectedId = ""; clearForm() }
     }
 
-    Component.onCompleted: {
-        scheduleFile.reload()
-        reminderTimer.start()
+    FileView {
+        id: scheduleFile
+        path: root.storagePath
+        onLoaded: {
+            try {
+                let parsed = JSON.parse(scheduleFile.text())
+                if (Array.isArray(parsed)) root.events = parsed
+            } catch(e) {}
+        }
     }
 
-    // ── Reminder Timer (checks every 60s) ──
-    Timer {
-        id: reminderTimer
-        interval: 60000
-        repeat: true
-        running: false
-        onTriggered: root.checkReminders()
-    }
-
-    function checkReminders() {
-        const now = new Date()
-        const todayStr = Qt.formatDate(now, "yyyy-MM-dd")
-        const timeStr  = Qt.formatTime(now, "HH:mm")
-        let changed = false
-
-        root.events.forEach((ev, i) => {
-            // Determine effective date for today
-            let matches = false
-            if (ev.recurrence === "daily") {
-                matches = ev.time === timeStr
-            } else if (ev.recurrence === "weekly") {
-                const evDay = new Date(ev.date).getDay()
-                matches = now.getDay() === evDay && ev.time === timeStr
-            } else if (ev.recurrence === "monthly") {
-                const evDayOfMonth = new Date(ev.date).getDate()
-                matches = now.getDate() === evDayOfMonth && ev.time === timeStr
-            } else {
-                matches = ev.date === todayStr && ev.time === timeStr
-            }
-
-            if (matches && ev.lastFired !== `${todayStr}T${timeStr}`) {
-                notifyProc.command = ["notify-send", "-a", "Nandoroid", "-i", "calendar", ev.title, ev.date + " " + ev.time]
-                notifyProc.running = true
-                root.events[i] = Object.assign({}, ev, { lastFired: `${todayStr}T${timeStr}` })
-                changed = true
-            }
-        })
-
-        if (changed) { root.events = root.events.slice(); save() }
-    }
-
-    Process { id: notifyProc; running: false }
+    Component.onCompleted: scheduleFile.reload()
 
     // ── State ──
     property string selectedId: ""
     property string formTitle: ""
     property string formDate: Qt.formatDate(new Date(), "yyyy-MM-dd")
     property string formTime: "09:00"
+    property string formEndTime: "10:00"
     property string formRecurrence: "once" // once | daily | weekly | monthly
-
     property string formDescription: ""
 
     function clearForm() {
         formTitle = ""; formDate = Qt.formatDate(new Date(), "yyyy-MM-dd")
-        formTime = "09:00"; formRecurrence = "once"; formDescription = ""
+        formTime = "09:00"; formEndTime = "10:00"; formRecurrence = "once"; formDescription = ""
     }
 
     // Auto-save debounce for existing events
@@ -117,12 +62,14 @@ Item {
         onTriggered: {
             if (!root.selectedId || !root.formTitle.trim()) return
             const descVal = root.formDescription.trim() ? root.formDescription.trim() : undefined
-            root.events = root.events.map(function(e) {
-                if (e.id === root.selectedId) {
-                    return Object.assign({}, e, { title: root.formTitle, date: root.formDate, time: root.formTime, recurrence: root.formRecurrence, description: descVal })
-                }
-                return e
-            })
+            root.events = root.events.map(e => e.id === root.selectedId ? Object.assign({}, e, {
+                title: root.formTitle, 
+                date: root.formDate, 
+                time: root.formTime, 
+                endTime: root.formEndTime,
+                recurrence: root.formRecurrence, 
+                description: descVal 
+            }) : e)
             root.save()
         }
     }
@@ -131,17 +78,28 @@ Item {
         if (!formTitle.trim()) return
         const descVal = formDescription.trim() ? formDescription.trim() : undefined
         if (selectedId) {
-            root.events = root.events.map(function(e) {
-                if (e.id === selectedId) {
-                    return Object.assign({}, e, { title: formTitle, date: formDate, time: formTime, recurrence: formRecurrence, description: descVal })
-                }
-                return e
-            })
+            root.events = root.events.map(e => e.id === selectedId ? Object.assign({}, e, { 
+                title: formTitle, 
+                date: formDate, 
+                time: formTime, 
+                endTime: formEndTime,
+                recurrence: formRecurrence, 
+                description: descVal 
+            }) : e)
         } else {
-            const newEv = { id: makeId(), title: formTitle, date: formDate, time: formTime, recurrence: formRecurrence, description: descVal, lastFired: "" }
+            const newEv = { 
+                id: Date.now().toString(36), 
+                title: formTitle, 
+                date: formDate, 
+                time: formTime, 
+                endTime: formEndTime,
+                recurrence: formRecurrence, 
+                description: descVal, 
+                lastFired: "" 
+            }
             root.events = root.events.concat([newEv])
         }
-        save()
+        root.save()
         selectedId = ""
         clearForm()
     }
@@ -223,6 +181,7 @@ Item {
                             StyledText {
                                 text: {
                                     let d = modelData.date + " " + modelData.time
+                                    if (modelData.endTime) d += " - " + modelData.endTime
                                     if (modelData.recurrence !== "once") d += " · " + modelData.recurrence
                                     return d
                                 }
@@ -257,6 +216,7 @@ Item {
                                 root.formTitle = modelData.title
                                 root.formDate = modelData.date
                                 root.formTime = modelData.time
+                                root.formEndTime = modelData.endTime || ""
                                 root.formRecurrence = modelData.recurrence
                                 root.formDescription = modelData.description || ""
                                 root.selectedId = modelData.id
@@ -342,9 +302,9 @@ Item {
                     }
                 }
 
-                // Time
+                // Start Time
                 Rectangle {
-                    Layout.preferredWidth: 110; implicitHeight: 44
+                    Layout.fillWidth: true; implicitHeight: 44
                     radius: Appearance.rounding.small
                     color: Appearance.m3colors.m3surfaceContainer
                     border.color: timeField.activeFocus ? Appearance.colors.colPrimary : "transparent"
@@ -361,6 +321,29 @@ Item {
                             color: Appearance.colors.colOnLayer1
                             inputMask: "99:99"
                             onTextChanged: { root.formTime = text; if(root.selectedId && timeField.activeFocus) autoSaveTimer.restart() }
+                        }
+                    }
+                }
+
+                // End Time
+                Rectangle {
+                    Layout.fillWidth: true; implicitHeight: 44
+                    radius: Appearance.rounding.small
+                    color: Appearance.m3colors.m3surfaceContainer
+                    border.color: endTimeField.activeFocus ? Appearance.colors.colPrimary : "transparent"
+                    border.width: 2
+                    RowLayout {
+                        anchors.fill: parent; anchors.margins: 10; spacing: 6
+                        MaterialSymbol { text: "event_busy"; iconSize: 16; color: Appearance.colors.colSubtext }
+                        TextInput {
+                            id: endTimeField
+                            Layout.fillWidth: true
+                            text: root.formEndTime
+                            font.family: Appearance.font.family.main
+                            font.pixelSize: Appearance.font.pixelSize.small
+                            color: Appearance.colors.colOnLayer1
+                            inputMask: "99:99"
+                            onTextChanged: { root.formEndTime = text; if(root.selectedId && endTimeField.activeFocus) autoSaveTimer.restart() }
                         }
                     }
                 }

--- a/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashboardContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Dashboard/DashboardContent.qml
@@ -237,7 +237,7 @@ Item {
                 // Centered within the strip, same as the Column's horizontalCenter
                 x: Math.round((tabStrip.width - root.tabButtonSize) / 2)
                 width: root.tabButtonSize
-                radius: Appearance.rounding.small
+                radius: 16
 
                 // Elastic stretch: idx1 snaps fast, idx2 follows slowly
                 property int idx1: 0

--- a/dotfiles/.config/quickshell/nandoroid/panels/NotificationCenter/NotificationCenterContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/NotificationCenter/NotificationCenterContent.qml
@@ -126,6 +126,16 @@ Item {
                                     NumberAnimation { target: bellRotation; property: "angle"; from: 15; to: -10; duration: 250; easing.type: Easing.InOutSine }
                                     NumberAnimation { target: bellRotation; property: "angle"; from: -10; to: 0; duration: 200; easing.type: Easing.OutSine }
                                 }
+
+                                Connections {
+                                    target: Notifications
+                                    function onListChanged() {
+                                        // Only trigger if empty and not from the Clear All button (which handles its own animation timing)
+                                        if (Notifications.list.length === 0 && !root._triggeredByClear) {
+                                            bellSwingAnim.restart()
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/dotfiles/.config/quickshell/nandoroid/panels/NotificationCenter/NotificationCenterContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/NotificationCenter/NotificationCenterContent.qml
@@ -153,7 +153,8 @@ Item {
 
                     SegmentedButton {
                         isHighlighted: Notifications.silent
-                        implicitWidth: 40
+                        forcePill: true
+                        implicitWidth: 56
                         implicitHeight: 40
                         iconName: Notifications.silent ? "notifications_off" : "notifications_active"
                         iconSize: 20
@@ -170,6 +171,7 @@ Item {
                     SegmentedWrapper {
                         Layout.fillWidth: true
                         Layout.preferredHeight: 40
+                        forcePill: true
                         smallRadius: 4
                         color: Appearance.m3colors.m3surfaceContainerHigh
                         
@@ -182,8 +184,9 @@ Item {
                     }
 
                     SegmentedButton {
-                        implicitWidth: 40
+                        implicitWidth: 56
                         implicitHeight: 40
+                        forcePill: true
                         iconName: "delete_sweep"
                         iconSize: 20
                         enabled: Notifications.list.length > 0

--- a/dotfiles/.config/quickshell/nandoroid/panels/NotificationPopup/NotificationPopup.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/NotificationPopup/NotificationPopup.qml
@@ -40,8 +40,8 @@ Scope {
 
         Item {
             id: maskItem
-            anchors.left: parent.left
-            anchors.right: parent.right
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: listview.width
             anchors.top: parent.top
             anchors.topMargin: (Config.options?.statusBar?.height ?? 40) - 20
             height: listview.contentHeight + 100

--- a/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/BluetoothPanel.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/BluetoothPanel.qml
@@ -27,8 +27,8 @@ Rectangle {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 12
-        spacing: 8
+        anchors.margins: 14
+        spacing: 12
 
         // Header
         RowLayout {
@@ -117,7 +117,7 @@ Rectangle {
                         RippleButton {
                             Layout.fillWidth: true
                             implicitHeight: 56
-                            buttonRadius: 12
+                            buttonRadius: 16
                             colBackground: deviceItem.modelData.connected ? Functions.ColorUtils.mix(Appearance.colors.colLayer0, Appearance.colors.colPrimary, 0.92) : "transparent"
                             colBackgroundHover: deviceItem.modelData.connected ? colBackground : Appearance.colors.colLayer0Hover
                             onClicked: deviceItem.expanded = !deviceItem.expanded
@@ -247,8 +247,9 @@ Rectangle {
                 visible: BluetoothStatus.enabled
                 implicitWidth: btPairText.implicitWidth + 24
                 implicitHeight: 36
-                buttonRadius: 18
-                colBackground: Appearance.colors.colLayer2
+                buttonRadius: height / 2
+                colBackground: Appearance.colors.colLayer1
+                colBackgroundHover: Appearance.colors.colLayer1Hover
                 onClicked: {
                     GlobalStates.settingsPageIndex = 1;
                     GlobalStates.settingsBluetoothPairMode = true;
@@ -268,9 +269,9 @@ Rectangle {
             RippleButton {
                 implicitWidth: btDoneText.implicitWidth + 24
                 implicitHeight: 36
-                buttonRadius: 18
+                buttonRadius: height / 2
                 colBackground: Appearance.colors.colPrimary
-                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.12)
+                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.1)
                 onClicked: root.dismiss()
                 StyledText {
                     id: btDoneText

--- a/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/NightModePanel.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/NightModePanel.qml
@@ -24,8 +24,8 @@ Rectangle {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 12
-        spacing: 8
+        anchors.margins: 14
+        spacing: 12
 
         // ── Header ──
         RowLayout {
@@ -155,9 +155,9 @@ Rectangle {
             RippleButton {
                 implicitWidth: doneText.implicitWidth + 24
                 implicitHeight: 36
-                buttonRadius: 18
+                buttonRadius: height / 2
                 colBackground: Appearance.colors.colPrimary
-                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.12)
+                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.1)
                 onClicked: root.dismiss()
                 StyledText {
                     id: doneText

--- a/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/PowerProfilePanel.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/PowerProfilePanel.qml
@@ -51,8 +51,8 @@ Rectangle {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 12
-        spacing: 8
+        anchors.margins: 14
+        spacing: 12
 
         // ── Header ──
         RowLayout {
@@ -106,7 +106,7 @@ Rectangle {
 
                 Layout.fillWidth: true
                 implicitHeight: 64
-                buttonRadius: Appearance.rounding.normal
+                buttonRadius: 16
                 colBackground: isActive
                     ? Functions.ColorUtils.transparentize(Appearance.colors.colPrimary, 0.82)
                     : Appearance.colors.colLayer2
@@ -194,9 +194,9 @@ Rectangle {
             RippleButton {
                 implicitWidth: ppDoneText.implicitWidth + 24
                 implicitHeight: 36
-                buttonRadius: 18
+                buttonRadius: height / 2
                 colBackground: Appearance.colors.colPrimary
-                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.12)
+                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.1)
                 onClicked: root.dismiss()
                 StyledText {
                     id: ppDoneText

--- a/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/QuickSettingsContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/QuickSettingsContent.qml
@@ -585,7 +585,7 @@ Item {
             anchors {
                 verticalCenter: parent.verticalCenter
                 right: nearFull ? quickSlider.handle.right : parent.right
-                rightMargin: icon.nearFull ? 14 : 8
+                rightMargin: icon.nearFull ? 16 : 10
             }
             iconSize: 20
             color: nearFull ? Appearance.colors.colOnPrimary : Appearance.colors.colOnSecondaryContainer
@@ -784,6 +784,72 @@ Item {
                         font.pixelSize: Appearance.font.pixelSize.small
                         color: Appearance.m3colors.m3onSurface
                         Layout.fillWidth: true
+                    }
+                }
+            }
+        }
+
+        // ── Interactive Key Helpers (Edit Mode) ──
+        Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: 40
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer1
+            visible: root.editMode
+            opacity: root.editMode ? 1 : 0
+            Behavior on opacity { NumberAnimation { duration: 250 } }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 12
+                anchors.rightMargin: 12
+                spacing: 12
+
+                StyledText {
+                    text: "Edit Mode Hints"
+                    font.pixelSize: 11
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colOnLayer1
+                    opacity: 0.6
+                }
+
+                Item { Layout.fillWidth: true }
+
+                RowLayout {
+                    spacing: 14
+                    opacity: 0.8
+
+                    // Add/Remove
+                    RowLayout {
+                        spacing: 6
+                        StyledText { text: "Add/Remove"; font.pixelSize: 10; color: Appearance.colors.colOnLayer1 }
+                        Rectangle {
+                            width: 18; height: 18; radius: 4
+                            color: Appearance.m3colors.m3surfaceVariant
+                            StyledText { anchors.centerIn: parent; text: "L"; font.pixelSize: 10; font.weight: Font.Bold }
+                        }
+                    }
+
+                    // Resize
+                    RowLayout {
+                        spacing: 6
+                        StyledText { text: "Resize"; font.pixelSize: 10; color: Appearance.colors.colOnLayer1 }
+                        Rectangle {
+                            width: 18; height: 18; radius: 4
+                            color: Appearance.m3colors.m3surfaceVariant
+                            StyledText { anchors.centerIn: parent; text: "R"; font.pixelSize: 10; font.weight: Font.Bold }
+                        }
+                    }
+
+                    // Move
+                    RowLayout {
+                        spacing: 6
+                        StyledText { text: "Move"; font.pixelSize: 10; color: Appearance.colors.colOnLayer1 }
+                        Rectangle {
+                            width: 38; height: 18; radius: 4
+                            color: Appearance.m3colors.m3surfaceVariant
+                            StyledText { anchors.centerIn: parent; text: "Scroll"; font.pixelSize: 10; font.weight: Font.Bold }
+                        }
                     }
                 }
             }

--- a/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/ToggleDelegate.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/ToggleDelegate.qml
@@ -55,7 +55,7 @@ RippleButton {
     colBackgroundToggled: (hasMenu) ? Appearance.colors.colLayer2 : Appearance.colors.colPrimary
     colBackgroundToggledHover: (hasMenu) ? Appearance.colors.colLayer2Hover : Appearance.colors.colPrimary
     
-    buttonRadius: isToggled ? Appearance.rounding.large : height / 2
+    buttonRadius: isToggled ? 16 : height / 2
 
     property color colText: (isToggled && !hasMenu && enabled) ? Appearance.colors.colOnPrimary : Functions.ColorUtils.transparentize(Appearance.colors.colOnLayer2, enabled ? 0 : 0.7)
     property color colIcon: expandedSize ? (isToggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer3) : colText
@@ -110,8 +110,9 @@ RippleButton {
                     height: parent.height
                     radius: (root.hasMenu && root.isToggled) ? 12 : width / 2
                     color: {
-                        const baseColor = root.isToggled ? Appearance.colors.colPrimary : Appearance.colors.colLayer3
-                        const transparentizeAmount = (root.hasMenu) ? 0 : 1
+                        const isActive = root.isToggled
+                        const baseColor = isActive ? Appearance.colors.colPrimary : Appearance.colors.colLayer3
+                        const transparentizeAmount = (root.hasMenu && isActive) ? 0 : 1
                         return Functions.ColorUtils.transparentize(baseColor, transparentizeAmount)
                     }
 

--- a/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/WifiPanel.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/WifiPanel.qml
@@ -27,8 +27,8 @@ Rectangle {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 12
-        spacing: 8
+        anchors.margins: 14
+        spacing: 12
 
         // Header
         RowLayout {
@@ -109,8 +109,8 @@ Rectangle {
         Rectangle {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            radius: 16
-            color: Appearance.colors.colLayer0
+            radius: 12
+            color: "transparent"
             clip: true
 
             ListView {
@@ -125,7 +125,7 @@ Rectangle {
                     id: delegateRoot
                     required property var modelData
                     required property int index
-                    width: wifiList.width - 8
+                    width: wifiList.width
                     height: delegateCol.implicitHeight
 
                     ColumnLayout {
@@ -137,7 +137,7 @@ Rectangle {
                             id: networkItem
                             Layout.fillWidth: true
                             implicitHeight: 56
-                            buttonRadius: 12
+                            buttonRadius: 16
                             colBackground: {
                                 if (delegateRoot.modelData.active) return Functions.ColorUtils.mix(Appearance.colors.colLayer0, Appearance.colors.colPrimary, 0.85);
                                 if (delegateRoot.modelData.askingPassword) return Appearance.colors.colLayer2;
@@ -167,7 +167,7 @@ Rectangle {
                                 visible: delegateRoot.modelData.askingPassword
                                 color: parent.colBackground
                                 z: -1
-                                radius: 12
+                                radius: 16
                                 
                                 // Make bottom square
                                 Rectangle {
@@ -239,7 +239,7 @@ Rectangle {
                             visible: Layout.preferredHeight > 0
                             clip: true
                             color: Appearance.colors.colLayer2
-                            radius: 12
+                            radius: 16
                             opacity: delegateRoot.modelData.askingPassword ? 1 : 0
                             Behavior on Layout.preferredHeight { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
                             Behavior on opacity { NumberAnimation { duration: 200 } }
@@ -368,8 +368,9 @@ Rectangle {
             RippleButton {
                 implicitWidth: detailsText.implicitWidth + 24
                 implicitHeight: 36
-                buttonRadius: 18
-                colBackground: Appearance.colors.colLayer2
+                buttonRadius: height / 2
+                colBackground: Appearance.colors.colLayer1
+                colBackgroundHover: Appearance.colors.colLayer1Hover
                 onClicked: {
                     GlobalStates.settingsPageIndex = 0;
                     GlobalStates.settingsOpen = true;
@@ -388,9 +389,9 @@ Rectangle {
             RippleButton {
                 implicitWidth: doneText.implicitWidth + 24
                 implicitHeight: 36
-                buttonRadius: 18
+                buttonRadius: height / 2
                 colBackground: Appearance.colors.colPrimary
-                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.12)
+                colBackgroundHover: Qt.darker(Appearance.colors.colPrimary, 1.1)
                 onClicked: root.dismiss()
                 StyledText {
                     id: doneText

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/DynamicIsland.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/DynamicIsland.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import Quickshell
 import Quickshell.Widgets
 import "../../core"
+import "../../core/functions" as Functions
 import "../../services"
 import "../../widgets"
 import Quickshell.Hyprland
@@ -48,6 +49,7 @@ Item {
 
     readonly property string islandState: {
         if (Notifications.activePopup) return "notification"
+        if (ScreenRecord.active) return "recording"
         if (mediaShowing && MprisController.activePlayer) return "media"
         if (pomodoroActive) return "pomodoro"
         return "idle"
@@ -72,6 +74,7 @@ Item {
                 if (notifAppNameLabel.visible) w += Math.min(notifAppNameLabel.implicitWidth, 100) + 4
                 return w > 0 ? w + 4 : 0
             }
+            if (islandState === "recording") return 24
             if (islandState === "media") {
                 let w = 0
                 if (mediaLogo.visible) w += 20 + 6 // Icon + margin
@@ -118,6 +121,34 @@ Item {
             width: Math.min(implicitWidth, 100)
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignRight
+        }
+
+        Item {
+            anchors.right: parent.right
+            anchors.rightMargin: 4
+            anchors.verticalCenter: parent.verticalCenter
+            visible: islandState === "recording"
+            opacity: parent.width > 12 ? 1 : 0
+            width: 16
+            height: 16
+            Behavior on opacity { NumberAnimation { duration: 200 } }
+
+            MaterialSymbol {
+                id: recordIcon
+                anchors.centerIn: parent
+                text: "screen_record"
+                iconSize: 16
+                color: Appearance.m3colors.m3error
+                fill: 1
+                
+                SequentialAnimation on opacity {
+                    id: recordAnim
+                    running: recordIcon.visible
+                    loops: Animation.Infinite
+                    NumberAnimation { from: 1; to: 0.3; duration: 800; easing.type: Easing.InOutSine }
+                    NumberAnimation { from: 0.3; to: 1; duration: 800; easing.type: Easing.InOutSine }
+                }
+            }
         }
 
         // Application Icon with Fallback
@@ -207,6 +238,7 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            enabled: islandState === "notification"
             onClicked: {
                 if (islandState === "notification" && Notifications.activePopup) {
                     Notifications.attemptInvokeAction(Notifications.activePopup.notificationId, "default")
@@ -226,6 +258,7 @@ Item {
         
         width: {
             if (islandState === "notification") return notifSummaryLabel.visible ? Math.min(notifSummaryLabel.implicitWidth, 200) + 8 : 0
+            if (islandState === "recording") return recordTimeLabel.implicitWidth + 8
             if (islandState === "media") return mediaTitleLabel.visible ? Math.min(mediaTitleLabel.implicitWidth, 150) + 8 : 0
             if (islandState === "pomodoro") return pomoTimeLabel.implicitWidth + 8
             return 0
@@ -247,6 +280,20 @@ Item {
             color: Appearance.colors.colNotchText
             width: Math.min(implicitWidth, 200)
             elide: Text.ElideRight
+        }
+
+        StyledText {
+            id: recordTimeLabel
+            anchors.left: parent.left
+            anchors.leftMargin: 4
+            anchors.verticalCenter: parent.verticalCenter
+            text: Functions.General.formatDuration(ScreenRecord.seconds)
+            opacity: parent.width > 10 ? 1 : 0
+            Behavior on opacity { NumberAnimation { duration: 200 } }
+            font.pixelSize: 12; font.weight: Font.DemiBold
+            color: Appearance.colors.colNotchText
+            font.family: Appearance.font.family.numbers
+            visible: islandState === "recording"
         }
 
         StyledText {
@@ -281,6 +328,7 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            enabled: islandState === "notification"
             onClicked: {
                 if (islandState === "notification" && Notifications.activePopup) {
                     Notifications.discardNotification(Notifications.activePopup.notificationId)
@@ -316,10 +364,19 @@ Item {
                     HyprlandData.cycleLayout();
                     return;
                 }
+                
+                if (islandState === "recording") {
+                    if (mouse.button === Qt.LeftButton) {
+                        ScreenRecord.stop()
+                    }
+                    return;
+                }
+
                 if (mouse.button === Qt.RightButton) {
                     GlobalStates.overviewOpen = !GlobalStates.overviewOpen;
                     return;
                 }
+
                 if (islandState === "notification" && Notifications.activePopup) {
                     Notifications.activePopup.expanded = !Notifications.activePopup.expanded
                 } else if (islandState === "media") {

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
@@ -284,10 +284,7 @@ Item {
                 }
             }
 
-            // Screen Recording Indicator
-            RecordIndicator {
-                Layout.alignment: Qt.AlignVCenter
-            }
+
         }
     }
 

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
@@ -284,6 +284,16 @@ Item {
                 }
             }
 
+            // DND Indicator
+            MaterialSymbol {
+                visible: Notifications.silent
+                text: "notifications_paused"
+                iconSize: 16
+                fill: 1
+                color: Appearance.colors.colStatusBarText
+                Layout.alignment: Qt.AlignVCenter
+            }
+
 
         }
     }

--- a/dotfiles/.config/quickshell/nandoroid/scripts/videos/record.sh
+++ b/dotfiles/.config/quickshell/nandoroid/scripts/videos/record.sh
@@ -40,7 +40,7 @@ start_timer() {
     ( 
         while true; do
             SECONDS_ELAPSED=$((SECONDS_ELAPSED + 1))
-            jq ".screenRecord.seconds = $SECONDS_ELAPSED" "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+            jq ".screenRecord.seconds = $SECONDS_ELAPSED" "$STATE_FILE" > "${STATE_FILE}.tmp" && cat "${STATE_FILE}.tmp" > "$STATE_FILE"
             sleep 1
         done
     ) &
@@ -52,7 +52,7 @@ stop_timer() {
         kill "$TIMER_PID" 2>/dev/null
         wait "$TIMER_PID" 2>/dev/null
         TIMER_PID=""
-        jq ".screenRecord.seconds = 0" "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE" # setting it to 0 after killing the timer
+        jq ".screenRecord.seconds = 0" "$STATE_FILE" > "${STATE_FILE}.tmp" && cat "${STATE_FILE}.tmp" > "$STATE_FILE" # setting it to 0 after killing the timer
     fi
 }
 
@@ -72,7 +72,7 @@ getactivemonitor() {
 
 updatestate() {
     local state_value=$1
-    jq ".screenRecord.active = $state_value" "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    jq ".screenRecord.active = $state_value" "$STATE_FILE" > "${STATE_FILE}.tmp" && cat "${STATE_FILE}.tmp" > "$STATE_FILE"
     if [[ "$state_value" == "true" ]]; then
         start_timer
     else
@@ -94,7 +94,7 @@ for ((i=0;i<${#ARGS[@]};i++)); do
         if (( i+1 < ${#ARGS[@]} )); then
             MANUAL_REGION="${ARGS[i+1]}"
         else
-            notify-send "Recording cancelled" "No region specified for --region" -a 'Recorder' -t 3000 & disown
+            notify-send "Recording cancelled" "No region specified for --region" -a 'Recorder' -i media-record -t 3000 & disown
             updatestate false
             exit 1
         fi
@@ -106,13 +106,13 @@ for ((i=0;i<${#ARGS[@]};i++)); do
 done
 
 if pgrep wf-recorder > /dev/null; then
-    notify-send "Recording Stopped" "Video saved to $RECORDING_DIR" -a 'Recorder' -t 5000 &
+    notify-send "Recording Stopped" "Video saved to $RECORDING_DIR" -a 'Recorder' -i media-record -t 5000 &
     updatestate false
     pkill wf-recorder &
 else
     filename="recording_$(getdate).mp4"
     if [[ $FULLSCREEN_FLAG -eq 1 ]]; then
-        notify-send "Starting recording" "$filename" -a 'Recorder' -t 3000 & disown
+        notify-send "Starting recording" "$filename" -a 'Recorder' -i media-record -t 3000 & disown
         updatestate true
         if [[ $SOUND_FLAG -eq 1 ]]; then
             wf-recorder -o "$(getactivemonitor)" --pixel-format yuv420p -f "$filename" --audio="$(getaudiooutput)"
@@ -125,7 +125,7 @@ else
             region="$MANUAL_REGION"
         else
             if ! region="$(slurp 2>&1)"; then
-                notify-send "Recording cancelled" "Selection was cancelled" -a 'Recorder' -t 3000 & disown
+                notify-send "Recording cancelled" "Selection was cancelled" -a 'Recorder' -i media-record -t 3000 & disown
                 updatestate false
                 exit 1
             fi
@@ -137,7 +137,7 @@ else
         y="${pos#*,}"
         geometry="${x},${y} ${size}"
 
-        notify-send "Starting recording" "$filename" -a 'Recorder' -t 3000 & disown
+        notify-send "Starting recording" "$filename" -a 'Recorder' -i media-record -t 3000 & disown
         updatestate true
         if [[ $SOUND_FLAG -eq 1 ]]; then
             wf-recorder -o "$(getactivemonitor)" --pixel-format yuv420p -f "$filename" --geometry "$geometry" --audio="$(getaudiooutput)"

--- a/dotfiles/.config/quickshell/nandoroid/services/GameMode.qml
+++ b/dotfiles/.config/quickshell/nandoroid/services/GameMode.qml
@@ -5,6 +5,8 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 
+import "." 
+
 Singleton {
     id: root
 
@@ -12,6 +14,9 @@ Singleton {
 
     function toggle() {
         root.active = !root.active
+        // Synchronize with Do Not Disturb
+        Notifications.silent = root.active
+        
         if (root.active) {
             Quickshell.execDetached(["bash", "-c", `hyprctl --batch "keyword animations:enabled 0; keyword decoration:shadow:enabled 0; keyword decoration:blur:enabled 0; keyword general:gaps_in 0; keyword general:gaps_out 0; keyword general:border_size 1; keyword decoration:rounding 0; keyword general:allow_tearing 1"`])
         } else {

--- a/dotfiles/.config/quickshell/nandoroid/services/Notifications.qml
+++ b/dotfiles/.config/quickshell/nandoroid/services/Notifications.qml
@@ -24,6 +24,8 @@ Singleton {
     property bool silent: false
     property int idOffset: 0
 
+    onListChanged: if (list.length === 0) activePopup = null;
+
     // ── Grouping Logic ──
     property var groupsByAppName: {
         const groups = {};
@@ -212,6 +214,7 @@ Singleton {
     }
 
     function discardAllNotifications() {
+        root.activePopup = null;
         root.list.forEach(n => { if (n.timer) n.timer.stop(); });
         root.list = [];
         notifFileView.setText(stringifyList(root.list));

--- a/dotfiles/.config/quickshell/nandoroid/services/ScreenRecord.qml
+++ b/dotfiles/.config/quickshell/nandoroid/services/ScreenRecord.qml
@@ -44,7 +44,6 @@ Singleton {
     FileView {
         id: stateFileView
         path: root.stateFile
-        watchChanges: true
         onLoaded: {
             try {
                 const trimmed = stateFileView.text().trim();
@@ -58,6 +57,13 @@ Singleton {
                 console.error("[ScreenRecord] Failed to parse state:", e);
             }
         }
+    }
+
+    Timer {
+        interval: 1000
+        running: true
+        repeat: true
+        onTriggered: stateFileView.reload()
     }
 
     Component.onCompleted: {

--- a/dotfiles/.config/quickshell/nandoroid/shell.qml
+++ b/dotfiles/.config/quickshell/nandoroid/shell.qml
@@ -55,14 +55,14 @@ ShellRoot {
                 LOCAL_COMMIT=$(git rev-parse HEAD 2>/dev/null)
                 TAG_COMMIT=$(git rev-list -n 1 "$LATEST" 2>/dev/null)
                 if [ "$LOCAL_COMMIT" != "$TAG_COMMIT" ]; then
-                    notify-send -a "NAnDoroid" -i "$DIR/dotfiles/.config/quickshell/nandoroid/assets/icons/NAnDoroid.svg" "Update available" "An update is available ($LATEST)! Check Settings."
+                    notify-send -a "NAnDoroid" -i "$HOME/.config/quickshell/nandoroid/assets/icons/NAnDoroid.svg" "Update available" "An update is available ($LATEST)! Check Settings."
                 fi
             else
                 git fetch origin main >/dev/null 2>&1
                 LOCAL=$(git rev-parse HEAD 2>/dev/null)
                 REMOTE=$(git rev-parse origin/main 2>/dev/null)
                 if [ "$LOCAL" != "$REMOTE" ] && [ -n "$LOCAL" ] && [ -n "$REMOTE" ]; then
-                    notify-send -a "NAnDoroid" -i "$DIR/dotfiles/.config/quickshell/nandoroid/assets/icons/NAnDoroid.svg" "Update available" "An update is available (New Commits)! Check Settings."
+                    notify-send -a "NAnDoroid" -i "$HOME/.config/quickshell/nandoroid/assets/icons/NAnDoroid.svg" "Update available" "An update is available (New Commits)! Check Settings."
                 fi
             fi
         `]

--- a/dotfiles/.config/quickshell/nandoroid/shell.qml
+++ b/dotfiles/.config/quickshell/nandoroid/shell.qml
@@ -55,14 +55,14 @@ ShellRoot {
                 LOCAL_COMMIT=$(git rev-parse HEAD 2>/dev/null)
                 TAG_COMMIT=$(git rev-list -n 1 "$LATEST" 2>/dev/null)
                 if [ "$LOCAL_COMMIT" != "$TAG_COMMIT" ]; then
-                    notify-send -t 10000 -i system-software-update "Nandoroid Shell" "An update is available ($LATEST)! Check Settings."
+                    notify-send -a "NAnDoroid" -i "$DIR/dotfiles/.config/quickshell/nandoroid/assets/icons/NAnDoroid.svg" "Update available" "An update is available ($LATEST)! Check Settings."
                 fi
             else
                 git fetch origin main >/dev/null 2>&1
                 LOCAL=$(git rev-parse HEAD 2>/dev/null)
                 REMOTE=$(git rev-parse origin/main 2>/dev/null)
                 if [ "$LOCAL" != "$REMOTE" ] && [ -n "$LOCAL" ] && [ -n "$REMOTE" ]; then
-                    notify-send -t 10000 -i system-software-update "Nandoroid Shell" "An update is available (New Commits)! Check Settings."
+                    notify-send -a "NAnDoroid" -i "$DIR/dotfiles/.config/quickshell/nandoroid/assets/icons/NAnDoroid.svg" "Update available" "An update is available (New Commits)! Check Settings."
                 fi
             fi
         `]

--- a/dotfiles/.config/quickshell/nandoroid/widgets/NotificationGroup.qml
+++ b/dotfiles/.config/quickshell/nandoroid/widgets/NotificationGroup.qml
@@ -20,6 +20,10 @@ MouseArea { // Notification group area
     property bool expanded: false
     property bool popup: false
     property real padding: 10
+    
+    property bool isFirst: false
+    property bool isLast: false
+    
     implicitHeight: background.implicitHeight
 
     property real dragConfirmThreshold: 70 // Drag further to discard notification
@@ -115,17 +119,24 @@ MouseArea { // Notification group area
         }
     }
 
+
     StyledRectangularShadow {
         target: background
         visible: popup
+        opacity: 0.3 // Significantly reduced opacity for a subtle look
     }
 
-    Rectangle { // Background of the notification
+    SegmentedWrapper { // Background of the notification
         id: background
         anchors.left: parent.left
         width: parent.width
         color: popup ? Appearance.m3colors.m3surfaceContainer : Appearance.colors.colLayer2
-        radius: Appearance.rounding.normal
+        orientation: Qt.Vertical
+        maxRadius: 24
+        
+        forceFirst: root.isFirst
+        forceLast: root.isLast
+        
         anchors.leftMargin: root.xOffset
 
         Behavior on anchors.leftMargin {
@@ -137,7 +148,6 @@ MouseArea { // Notification group area
             }
         }
         
-        clip: true
         implicitHeight: root.expanded ? 
             row.implicitHeight + padding * 2 :
             Math.min(80, row.implicitHeight + padding * 2)
@@ -245,6 +255,7 @@ MouseArea { // Notification group area
                         required property var modelData
                         notificationObject: modelData
                         expanded: root.expanded
+                        
                         onlyNotification: (root.notificationCount === 1)
                         opacity: (!root.expanded && index == 1 && root.notificationCount > 2) ? 0.5 : 1
                         visible: root.expanded || (index < 2)

--- a/dotfiles/.config/quickshell/nandoroid/widgets/NotificationItem.qml
+++ b/dotfiles/.config/quickshell/nandoroid/widgets/NotificationItem.qml
@@ -229,9 +229,12 @@ Item { // Notification item area
                         }
                     }
 
+
                     ScrollEdgeFade {
                         target: actionsFlickable
                         vertical: false
+                        fadeSize: 20
+                        color: Functions.ColorUtils.transparentize(Appearance.m3colors.m3shadow, 0.96) // Super subtle
                     }
 
                     StyledFlickable { // Notification actions

--- a/dotfiles/.config/quickshell/nandoroid/widgets/NotificationListView.qml
+++ b/dotfiles/.config/quickshell/nandoroid/widgets/NotificationListView.qml
@@ -13,7 +13,7 @@ StyledListView {
     id: root
     property bool popup: false
 
-    spacing: 12
+    spacing: 4
 
     model: ScriptModel {
         values: root.popup ? Notifications.popupAppNameList : Notifications.appNameList
@@ -23,6 +23,10 @@ StyledListView {
         required property var modelData
         popup: root.popup
         width: ListView.view.width
+        
+        isFirst: index === 0
+        isLast: index === ListView.view.count - 1
+        
         notificationGroup: popup ? 
             Notifications.popupGroupsByAppName[modelData] :
             Notifications.groupsByAppName[modelData]

--- a/dotfiles/.config/quickshell/nandoroid/widgets/SegmentedButton.qml
+++ b/dotfiles/.config/quickshell/nandoroid/widgets/SegmentedButton.qml
@@ -20,6 +20,7 @@ SegmentedWrapper {
     property bool isHighlighted: false
     property real leftPadding: 16
     property real rightPadding: 16
+    property real spacing: 8
     readonly property bool hovered: button.realHovered
     
     property color colActive: Appearance.m3colors.m3primary
@@ -65,7 +66,7 @@ SegmentedWrapper {
             Row {
                 id: contentRow
                 anchors.centerIn: parent
-                spacing: 8
+                spacing: root.spacing
                 
                 MaterialSymbol {
                     visible: root.iconName !== ""


### PR DESCRIPTION
### Summary
This PR transitions Screen Recording activity and Do-Not-Disturb (DND) status off the legacy Status Bar modules, integrating them into the modern Android 16-inspired Dynamic Island notch and native Right Cluster. It also includes comprehensive UI/UX refactors for the Dashboard, Quick Settings, and Notification systems to align with the new design language.

### Key Changes
**1. Dashboard and Schedule Overhaul**
- **Elastic Navigation**: Implemented a vertical tab strip with elastic highlight animations and smooth transitions.
- **Smart Schedule**: Added End Time properties for events and integrated tooltips into the Calendar widget.
- **UI Refinement**: Standardized padding, radius, and typography across all Dashboard modules (Calendar, Schedule, Notepad).

**2. Quick Settings: Android 16 Redesign**
- **Layout Strategy**: Realigned header panels (Wifi, Bluetooth, Power, Night Mode) to a centered, card-based aesthetic.
- **Visual Polish**: Refactored ToggleDelegate and detail panels to ensure Material 3 color schemes are applied with better contrast.

**3. Notification Center and Popup Improvements**
- **Aesthetic Update**: Refined visual styles for NotificationGroup and NotificationItem for better organization.
- **Bell Animation Fix**: Fixed the bell icon shake logic to trigger correctly when notifications are manually dismissed one by one.
- **Popup Mask Fix**: Adjusted the NotificationPopup mask width to strictly cover the card area, preventing visual artifacts in the notch.

**4. Dynamic Island Integration**
- **Screen Recording HUD**: Moved screen recording status entirely into the Dynamic Island as an Ongoing Activity.
- **Visual Indicators**: Added a blinking red recording icon in the Left Ear and an active timer in the Right Ear.
- **Simplified Actions**: Implemented Left-Click on the notch to instantly stop and save the video, removing the need for a separate right-click action.

**5. Core Logic and Syncing**
- **Gaming Mode and DND Sync**: Synchronized the Game Mode toggle to automatically trigger the Do Not Disturb (DND) state.
- **DND Status Bar Indicator**: Added a `notifications_paused` icon to the status bar right cluster for accurate silent-mode visibility.
- **Record Script Watcher Fix**: Updated [record.sh](cci:7://file:///home/naive/Projects/nandoroid-shell/dotfiles/.config/quickshell/nandoroid/scripts/videos/record.sh:0:0-0:0) JSON updates to use `cat` streams instead of `mv`. This prevents the UI from losing file watchers due to inode changes, ensuring the recording timer and Quick Settings text stay synchronized.
- **Notification Icons**: Ensured all recording-related system notifications now display the proper `media-record` icon instead of a blank fallback.
