### PR TITLE
Feat/centered statusbar

### DIFF
--- a/dotfiles/.config/quickshell/nandoroid/core/Appearance.qml
+++ b/dotfiles/.config/quickshell/nandoroid/core/Appearance.qml
@@ -148,18 +148,17 @@ Singleton {
         property bool statusBarDarkText: false
 
         // When background is shown, gradient + adaptive text mode are ignored
-        readonly property bool statusBarBgActive: Config.ready && Config.options.statusBar
-            ? (Config.options.statusBar.backgroundStyle ?? 0) > 0
+        readonly property bool statusBarAlwaysSolid: Config.ready && Config.options.statusBar
+            ? (Config.options.statusBar.backgroundStyle ?? 0) === 1
             : false
 
-        // Gradient is only active when backgroundStyle = 0 AND useGradient = true
-        readonly property bool statusBarGradientActive: !statusBarBgActive
+        // Gradient is only active when backgroundStyle != 1 AND useGradient = true
+        readonly property bool statusBarGradientActive: !statusBarAlwaysSolid
             && (Config.ready && Config.options.statusBar ? (Config.options.statusBar.useGradient ?? true) : true)
 
-        // Resolved dark text: locked to wallpaper-based detection if bg is active (theme decides),
-        // otherwise respects user setting
+        // Resolved dark text: respects user setting if not ALWAYS solid
         readonly property bool resolvedStatusBarDarkText: {
-            if (statusBarBgActive) return false; // background mode: use theme text (always on surface)
+            if (statusBarAlwaysSolid) return false; // background mode: use theme text (always on surface)
             if (!Config.ready || !Config.options.statusBar) return statusBarDarkText;
             const mode = Config.options.statusBar.textColorMode ?? "adaptive";
             if (mode === "dark") return true;
@@ -167,9 +166,7 @@ Singleton {
             return statusBarDarkText; // adaptive
         }
 
-        property color colStatusBarText: statusBarBgActive
-            ? m3colors.m3onSurface
-            : (resolvedStatusBarDarkText ? "#1E1E1E" : "#F5F5F5")
+        property color colStatusBarText: resolvedStatusBarDarkText ? "#1E1E1E" : "#F5F5F5"
         property color colStatusBarSubtext: Functions.ColorUtils.applyAlpha(colStatusBarText, 0.7)
         property color colStatusBarGradientStart: {
             if (!statusBarGradientActive) return "transparent";

--- a/dotfiles/.config/quickshell/nandoroid/core/Config.qml
+++ b/dotfiles/.config/quickshell/nandoroid/core/Config.qml
@@ -232,6 +232,8 @@ Singleton {
             // --- Status Bar ---
             property JsonObject statusBar: JsonObject {
                 property real height: 40
+                property string layoutStyle: "standard" // standard, centered
+                property int centeredWidth: 1200
                 property string textColorMode: "adaptive" // adaptive, light, dark
                 property bool useGradient: true
                 // 0 = None (transparent), 1 = Always (solid), 2 = Adaptive (show when window active)

--- a/dotfiles/.config/quickshell/nandoroid/core/GlobalStates.qml
+++ b/dotfiles/.config/quickshell/nandoroid/core/GlobalStates.qml
@@ -36,7 +36,7 @@ Singleton {
     // --- Media Notch Timing Logic ---
     Timer { 
         id: mediaNotchTimer
-        interval: 500 // Increased from 200ms
+        interval: 2000 // Popup persists for 2 seconds
         onTriggered: {
             mediaNotchOpen = false;
             activeMediaNotchScreen = null;

--- a/dotfiles/.config/quickshell/nandoroid/panels/Lock/LockSurface.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Lock/LockSurface.qml
@@ -117,37 +117,75 @@ MouseArea {
         height: Appearance.sizes.statusBarHeight
         z: 10
 
+        readonly property bool isCentered: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.layoutStyle === "centered" : false
+        readonly property real centeredWidth: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.centeredWidth : 1200
+        readonly property real sidePadding: isCentered ? Math.round((parent.width - Math.min(centeredWidth, parent.width - 40)) / 2) : 12
+        readonly property int cornerRadius: (Config.ready && Config.options.statusBar?.backgroundCornerRadius) || 20
+
         // 1. Solid background (follows system config)
         Rectangle {
             id: barBg
-            anchors.fill: parent
-            color: (Config.ready && Config.options.statusBar?.backgroundStyle !== 0) 
-                   ? Appearance.colors.colStatusBarSolid 
-                   : "transparent"
+            anchors.top: parent.top
+            anchors.horizontalCenter: parent.horizontalCenter
+            
+            readonly property bool showBg: (Config.ready && Config.options.statusBar?.backgroundStyle !== 0)
+            
+            width: (lockStatusBarContainer.isCentered && showBg) ? Math.min(lockStatusBarContainer.centeredWidth, parent.width - 40) : parent.width
+            height: parent.height + (lockStatusBarContainer.isCentered && showBg ? lockStatusBarContainer.cornerRadius : 0)
+            anchors.topMargin: (lockStatusBarContainer.isCentered && showBg) ? -lockStatusBarContainer.cornerRadius : 0
+            
+            color: showBg ? Appearance.colors.colStatusBarSolid : "transparent"
+            radius: (lockStatusBarContainer.isCentered && showBg) ? lockStatusBarContainer.cornerRadius : 0
+
+            Behavior on width { NumberAnimation { duration: 400; easing.type: Easing.OutQuint } }
+            Behavior on anchors.topMargin { NumberAnimation { duration: 400; easing.type: Easing.OutQuint } }
 
             // concanve corners
+            // Standard Corners
             RoundCorner {
                 anchors.left: parent.left
                 anchors.top: parent.bottom
-                implicitSize: (Config.ready && Config.options.statusBar?.backgroundCornerRadius) || 20
+                implicitSize: lockStatusBarContainer.cornerRadius
                 color: barBg.color
                 corner: RoundCorner.CornerEnum.TopLeft
-                visible: barBg.color !== "transparent"
+                visible: barBg.showBg && !lockStatusBarContainer.isCentered
             }
             RoundCorner {
                 anchors.right: parent.right
                 anchors.top: parent.bottom
-                implicitSize: (Config.ready && Config.options.statusBar?.backgroundCornerRadius) || 20
+                implicitSize: lockStatusBarContainer.cornerRadius
                 color: barBg.color
                 corner: RoundCorner.CornerEnum.TopRight
-                visible: barBg.color !== "transparent"
+                visible: barBg.showBg && !lockStatusBarContainer.isCentered
+            }
+
+            // HUD Corners
+            RoundCorner {
+                anchors { right: parent.left; top: parent.top; topMargin: lockStatusBarContainer.cornerRadius }
+                implicitSize: lockStatusBarContainer.cornerRadius
+                color: barBg.color
+                corner: RoundCorner.CornerEnum.TopRight 
+                visible: barBg.showBg && lockStatusBarContainer.isCentered
+            }
+            RoundCorner {
+                anchors { left: parent.right; top: parent.top; topMargin: lockStatusBarContainer.cornerRadius }
+                implicitSize: lockStatusBarContainer.cornerRadius
+                color: barBg.color
+                corner: RoundCorner.CornerEnum.TopLeft
+                visible: barBg.showBg && lockStatusBarContainer.isCentered
             }
         }
 
         // 2. Gradient overlay
         Rectangle {
-            anchors.fill: parent
+            anchors {
+                left: parent.left
+                right: parent.right
+                top: parent.top
+            }
+            height: parent.height
             color: "transparent"
+            visible: (Config.ready && Config.options.statusBar?.backgroundStyle === 0)
             gradient: Gradient {
                 GradientStop { position: 0.0; color: Appearance.colors.colStatusBarGradientStart }
                 GradientStop { position: 1.0; color: Appearance.colors.colStatusBarGradientEnd }
@@ -191,7 +229,7 @@ MouseArea {
             RowLayout {
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
-                anchors.leftMargin: 12
+                anchors.leftMargin: lockStatusBarContainer.sidePadding + (lockStatusBarContainer.isCentered ? 12 : 0)
                 spacing: 8
                 StyledText {
                     text: SystemInfo.username + "  •  " + (Network.wifiEnabled ? (Network.networkName || "Offline") : "WiFi Off")
@@ -228,6 +266,7 @@ MouseArea {
                 // Battery
                 BatteryIndicator {
                     Layout.alignment: Qt.AlignVCenter
+                    color: Appearance.colors.colStatusBarText
                 }
 
                 // Notifications
@@ -257,7 +296,7 @@ MouseArea {
             PrivacyIndicator {
                 id: privacyIndicator
                 anchors.right: parent.right
-                anchors.rightMargin: 10
+                anchors.rightMargin: lockStatusBarContainer.sidePadding + (lockStatusBarContainer.isCentered ? 8 : -2)
                 anchors.verticalCenter: parent.verticalCenter
             }
         }

--- a/dotfiles/.config/quickshell/nandoroid/panels/NotificationCenter/NotificationCenter.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/NotificationCenter/NotificationCenter.qml
@@ -29,9 +29,17 @@ Variants {
         WlrLayershell.keyboardFocus: (GlobalStates.notificationCenterOpen && isActive) ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
         color: "transparent"
 
+        readonly property bool isCentered: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.layoutStyle === "centered" : false
+        readonly property real centeredWidth: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.centeredWidth : 1200
+        readonly property real sidePadding: isCentered ? Math.round((modelData.width - Math.min(centeredWidth, modelData.width - 40)) / 2) : 0
+
         anchors {
             top: true
             left: true
+        }
+
+        WlrLayershell.margins {
+            left: panelWindow.sidePadding
         }
 
         implicitWidth: contentLoader.item ? contentLoader.item.implicitWidth : 0
@@ -70,13 +78,16 @@ Variants {
                     name: "open"
                     when: GlobalStates.notificationCenterOpen && isActive
                     PropertyChanges { target: contentLoader; opacity: 1 }
-                    PropertyChanges { target: contentTransform; x: 0 }
+                    PropertyChanges { target: contentTransform; x: 0; y: 0 }
                 },
                 State {
                     name: "closed"
                     when: (!GlobalStates.notificationCenterOpen || !isActive)
                     PropertyChanges { target: contentLoader; opacity: 0 }
-                    PropertyChanges { target: contentTransform; x: -contentLoader.width - 40 }
+                    PropertyChanges { target: contentTransform; 
+                        x: panelWindow.isCentered ? 0 : -contentLoader.width - 40;
+                        y: panelWindow.isCentered ? -contentLoader.height - 40 : 0;
+                    }
                 }
             ]
 
@@ -86,7 +97,7 @@ Variants {
                     ParallelAnimation {
                         NumberAnimation {
                             target: contentTransform
-                            property: "x"
+                            properties: "x,y"
                             duration: Appearance.animation.elementMove.duration
                             easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
                         }
@@ -103,7 +114,7 @@ Variants {
                     ParallelAnimation {
                         NumberAnimation {
                             target: contentTransform
-                            property: "x"
+                            properties: "x,y"
                             duration: Appearance.animation.elementMoveExit.duration
                             easing.bezierCurve: Appearance.animationCurves.emphasized
                         }

--- a/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/QuickSettings.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/QuickSettings/QuickSettings.qml
@@ -29,9 +29,17 @@ Variants {
         WlrLayershell.keyboardFocus: (GlobalStates.quickSettingsOpen && isActive) ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
         color: "transparent"
 
+        readonly property bool isCentered: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.layoutStyle === "centered" : false
+        readonly property real centeredWidth: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.centeredWidth : 1200
+        readonly property real sidePadding: isCentered ? Math.round((modelData.width - Math.min(centeredWidth, modelData.width - 40)) / 2) : 0
+
         anchors {
             top: true
             right: true
+        }
+
+        WlrLayershell.margins {
+            right: panelWindow.sidePadding
         }
 
         implicitWidth: content.implicitWidth
@@ -70,13 +78,16 @@ Variants {
                     name: "open"
                     when: GlobalStates.quickSettingsOpen && isActive
                     PropertyChanges { target: content; opacity: 1 }
-                    PropertyChanges { target: contentTransform; x: 0 }
+                    PropertyChanges { target: contentTransform; x: 0; y: 0 }
                 },
                 State {
                     name: "closed"
                     when: (!GlobalStates.quickSettingsOpen || !isActive)
                     PropertyChanges { target: content; opacity: 0 }
-                    PropertyChanges { target: contentTransform; x: content.width + 40 }
+                    PropertyChanges { target: contentTransform; 
+                        x: panelWindow.isCentered ? 0 : content.width + 40;
+                        y: panelWindow.isCentered ? -content.height - 40 : 0;
+                    }
                 }
             ]
 
@@ -86,7 +97,7 @@ Variants {
                     ParallelAnimation {
                         NumberAnimation {
                             target: contentTransform
-                            property: "x"
+                            properties: "x,y"
                             duration: Appearance.animation.elementMove.duration
                             easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
                         }
@@ -103,7 +114,7 @@ Variants {
                     ParallelAnimation {
                         NumberAnimation {
                             target: contentTransform
-                            property: "x"
+                            properties: "x,y"
                             duration: Appearance.animation.elementMoveExit.duration
                             easing.bezierCurve: Appearance.animationCurves.emphasized
                         }

--- a/dotfiles/.config/quickshell/nandoroid/panels/Settings/pages/WallpaperStyle/WsStatusBar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Settings/pages/WallpaperStyle/WsStatusBar.qml
@@ -25,12 +25,16 @@ ColumnLayout {
                 Layout.topMargin: 12
                 spacing: 16
     
-                // Computed: background is active (style > 0)
-                readonly property bool sbBgActive: Config.ready && Config.options.statusBar
+                // Computed: background is ALWAYS active (style == 1)
+                readonly property bool sbAlwaysSolid: Config.ready && Config.options.statusBar
+                    ? (Config.options.statusBar.backgroundStyle ?? 0) === 1
+                    : false
+                // Computed: any background style is selected (style > 0)
+                readonly property bool sbAnyBgStyle: Config.ready && Config.options.statusBar
                     ? (Config.options.statusBar.backgroundStyle ?? 0) > 0
                     : false
-                // Gradient is active: only when bg is None + useGradient = true
-                readonly property bool sbGradientActive: !sbBgActive
+                // Gradient is active: only when bg is not ALWAYS solid + useGradient = true
+                readonly property bool sbGradientActive: !sbAlwaysSolid
                     && (Config.ready && Config.options.statusBar ? Config.options.statusBar.useGradient : true)
     
                 // Section Header
@@ -63,7 +67,7 @@ ColumnLayout {
                         orientation: Qt.Vertical
                         maxRadius: 20
                         color: Appearance.m3colors.m3surfaceContainerHigh
-                        opacity: parent.parent.sbBgActive ? 0.4 : 1.0
+                        opacity: parent.parent.sbAlwaysSolid ? 0.4 : 1.0
                         Behavior on opacity { NumberAnimation { duration: 200 } }
                         RowLayout {
                             id: statusBarTextRow
@@ -83,14 +87,14 @@ ColumnLayout {
                                     delegate: SegmentedButton {
                                         required property var modelData
                                         buttonText: modelData.label
-                                        enabled: !sbSettingsCol.parent.sbBgActive
+                                        enabled: !sbSettingsCol.parent.sbAlwaysSolid
                                         isHighlighted: Config.ready && Config.options.statusBar
                                             ? Config.options.statusBar.textColorMode === modelData.id
                                             : modelData.id === "adaptive"
                                         colActive: Appearance.m3colors.m3primary
                                         colActiveText: Appearance.m3colors.m3onPrimary
                                         colInactive: Appearance.m3colors.m3surfaceContainerLow
-                                        onClicked: if (Config.ready && Config.options.statusBar && !sbSettingsCol.parent.sbBgActive)
+                                        onClicked: if (Config.ready && Config.options.statusBar && !sbSettingsCol.parent.sbAlwaysSolid)
                                             Config.options.statusBar.textColorMode = modelData.id
                                     }
                                 }
@@ -98,14 +102,14 @@ ColumnLayout {
                         }
                     }
     
-                    // ── Use Gradient (disabled when bg is active) ──────────────
+                    // ── Use Gradient (disabled ONLY when background is ALWAYS active) ──────────────
                     SegmentedWrapper {
                         Layout.fillWidth: true
                         implicitHeight: statusBarGradientRow.implicitHeight + 32
                         orientation: Qt.Vertical
                         maxRadius: 20
                         color: Appearance.m3colors.m3surfaceContainerHigh
-                        opacity: sbSettingsCol.parent.sbBgActive ? 0.4 : 1.0
+                        opacity: sbSettingsCol.parent.sbAlwaysSolid ? 0.4 : 1.0
                         Behavior on opacity { NumberAnimation { duration: 200 } }
                         RowLayout {
                             id: statusBarGradientRow
@@ -115,7 +119,7 @@ ColumnLayout {
                             StyledText { text: "Use gradient"; Layout.fillWidth: true; color: Appearance.colors.colOnLayer1 }
                             AndroidToggle {
                                 checked: Config.ready && Config.options.statusBar ? Config.options.statusBar.useGradient : true
-                                onToggled: if (Config.ready && Config.options.statusBar && !sbSettingsCol.parent.sbBgActive)
+                                onToggled: if (Config.ready && Config.options.statusBar && !sbSettingsCol.parent.sbAlwaysSolid)
                                     Config.options.statusBar.useGradient = !Config.options.statusBar.useGradient
                             }
                         }
@@ -227,14 +231,14 @@ ColumnLayout {
                         }
                     }
     
-                    // ── Corner Radius (only visible when background is active) ──
+                    // ── Corner radius (visible when ANY background style is active) ──
                     SegmentedWrapper {
                         Layout.fillWidth: true
                         implicitHeight: sbCornerRow.implicitHeight + 32
                         orientation: Qt.Vertical
                         maxRadius: 20
                         color: Appearance.m3colors.m3surfaceContainerHigh
-                        visible: sbSettingsCol.parent.sbBgActive
+                        visible: sbSettingsCol.parent.sbAnyBgStyle
                         RowLayout {
                             id: sbCornerRow
                             anchors.fill: parent; anchors.margins: 16

--- a/dotfiles/.config/quickshell/nandoroid/panels/Settings/pages/WallpaperStyle/WsStatusBar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Settings/pages/WallpaperStyle/WsStatusBar.qml
@@ -202,10 +202,31 @@ ColumnLayout {
                         }
                     }
 
+                    // ── Autohide Toggle ──────────────
+                    SegmentedWrapper {
+                        Layout.fillWidth: true
+                        implicitHeight: autohideRow.implicitHeight + 32
+                        orientation: Qt.Vertical
+                        maxRadius: 20
+                        color: Appearance.m3colors.m3surfaceContainerHigh
+                        RowLayout {
+                            id: autohideRow
+                            anchors.fill: parent; anchors.margins: 16
+                            spacing: 16
+                            MaterialSymbol { text: "visibility_off"; iconSize: 24; color: Appearance.colors.colPrimary }
+                            StyledText { text: "Autohide status bar"; Layout.fillWidth: true; color: Appearance.colors.colOnLayer1 }
+                            AndroidToggle {
+                                checked: Config.ready && Config.options.statusBar ? Config.options.statusBar.autohide : false
+                                onToggled: if (Config.ready && Config.options.statusBar)
+                                    Config.options.statusBar.autohide = !Config.options.statusBar.autohide
+                            }
+                        }
+                    }
+
                     // ── Centered Width (only visible when centered is active) ──
                     SegmentedWrapper {
                         Layout.fillWidth: true
-                        implicitHeight: centeredWidthRow.implicitHeight + 32
+                        implicitHeight: centeredWidthRow.implicitHeight + 36
                         orientation: Qt.Vertical
                         maxRadius: 20
                         color: Appearance.m3colors.m3surfaceContainerHigh
@@ -213,11 +234,21 @@ ColumnLayout {
                         RowLayout {
                             id: centeredWidthRow
                             anchors.fill: parent; anchors.margins: 16
-                            spacing: 16
-                            MaterialSymbol { text: "width_full"; iconSize: 24; color: Appearance.colors.colPrimary }
-                            StyledText { text: "Centered width"; Layout.fillWidth: true; color: Appearance.colors.colOnLayer1 }
+                            spacing: 20
+
+                            RowLayout {
+                                spacing: 16
+                                Layout.preferredWidth: 70 // Ramped down to give maximum space to slider
+                                MaterialSymbol { text: "width_full"; iconSize: 24; color: Appearance.colors.colPrimary }
+                                StyledText { 
+                                    text: "Centered width"
+                                    Layout.fillWidth: true
+                                    color: Appearance.colors.colOnLayer1 
+                                }
+                            }
+
                             StyledSlider {
-                                Layout.preferredWidth: 160
+                                Layout.fillWidth: true
                                 from: 800; to: 2000; stepSize: 50
                                 value: Config.ready && Config.options.statusBar ? (Config.options.statusBar.centeredWidth ?? 1200) : 1200
                                 onMoved: if (Config.ready && Config.options.statusBar)
@@ -227,14 +258,16 @@ ColumnLayout {
                                 text: Math.round(Config.ready && Config.options.statusBar
                                     ? (Config.options.statusBar.centeredWidth ?? 1200) : 1200).toString() + "px"
                                 color: Appearance.colors.colOnLayer1
+                                Layout.preferredWidth: 50
+                                horizontalAlignment: Text.AlignRight
                             }
                         }
                     }
-    
+
                     // ── Corner radius (visible when ANY background style is active) ──
                     SegmentedWrapper {
                         Layout.fillWidth: true
-                        implicitHeight: sbCornerRow.implicitHeight + 32
+                        implicitHeight: sbCornerRow.implicitHeight + 36
                         orientation: Qt.Vertical
                         maxRadius: 20
                         color: Appearance.m3colors.m3surfaceContainerHigh
@@ -242,12 +275,22 @@ ColumnLayout {
                         RowLayout {
                             id: sbCornerRow
                             anchors.fill: parent; anchors.margins: 16
-                            spacing: 16
-                            MaterialSymbol { text: "rounded_corner"; iconSize: 24; color: Appearance.colors.colPrimary }
-                            StyledText { text: "Corner radius"; Layout.fillWidth: true; color: Appearance.colors.colOnLayer1 }
+                            spacing: 20
+
+                            RowLayout {
+                                spacing: 16
+                                Layout.preferredWidth: 70
+                                MaterialSymbol { text: "rounded_corner"; iconSize: 24; color: Appearance.colors.colPrimary }
+                                StyledText { 
+                                    text: "Corner radius"
+                                    Layout.fillWidth: true
+                                    color: Appearance.colors.colOnLayer1 
+                                }
+                            }
+
                             StyledSlider {
-                                Layout.preferredWidth: 160
-                                from: 0; to: 40; stepSize: 1
+                                Layout.fillWidth: true
+                                from: 0; to: 20; stepSize: 1
                                 value: Config.ready && Config.options.statusBar ? (Config.options.statusBar.backgroundCornerRadius ?? 20) : 20
                                 onMoved: if (Config.ready && Config.options.statusBar)
                                     Config.options.statusBar.backgroundCornerRadius = Math.round(value)
@@ -256,10 +299,11 @@ ColumnLayout {
                                 text: Math.round(Config.ready && Config.options.statusBar
                                     ? (Config.options.statusBar.backgroundCornerRadius ?? 20) : 20).toString() + "px"
                                 color: Appearance.colors.colOnLayer1
+                                Layout.preferredWidth: 50
+                                horizontalAlignment: Text.AlignRight
                             }
                         }
-                    }
-    
+                    }    
                     // ── Workspace count ──────────────────────────────────────────
                     SegmentedWrapper {
                         Layout.fillWidth: true

--- a/dotfiles/.config/quickshell/nandoroid/panels/Settings/pages/WallpaperStyle/WsStatusBar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/Settings/pages/WallpaperStyle/WsStatusBar.qml
@@ -159,6 +159,73 @@ ColumnLayout {
                             }
                         }
                     }
+
+                    // ── Layout Style (Standard / Centered) ────────────
+                    SegmentedWrapper {
+                        Layout.fillWidth: true
+                        implicitHeight: layoutStyleRow.implicitHeight + 36
+                        orientation: Qt.Vertical
+                        maxRadius: 20
+                        color: Appearance.m3colors.m3surfaceContainerHigh
+                        RowLayout {
+                            id: layoutStyleRow
+                            anchors.fill: parent
+                            anchors.margins: 16
+                            spacing: 16
+                            MaterialSymbol { text: "center_focus_strong"; iconSize: 24; color: Appearance.colors.colPrimary }
+                            StyledText { text: "Layout Style"; Layout.fillWidth: true; color: Appearance.colors.colOnLayer1 }
+                            RowLayout {
+                                spacing: 2
+                                Repeater {
+                                    model: [
+                                        { id: "standard", label: "Standard" },
+                                        { id: "centered", label: "Centered (HUD)" }
+                                    ]
+                                    delegate: SegmentedButton {
+                                        required property var modelData
+                                        buttonText: modelData.label
+                                        isHighlighted: Config.ready && Config.options.statusBar
+                                            ? Config.options.statusBar.layoutStyle === modelData.id
+                                            : modelData.id === "standard"
+                                        colActive: Appearance.m3colors.m3primary
+                                        colActiveText: Appearance.m3colors.m3onPrimary
+                                        colInactive: Appearance.m3colors.m3surfaceContainerLow
+                                        onClicked: if (Config.ready && Config.options.statusBar)
+                                            Config.options.statusBar.layoutStyle = modelData.id
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // ── Centered Width (only visible when centered is active) ──
+                    SegmentedWrapper {
+                        Layout.fillWidth: true
+                        implicitHeight: centeredWidthRow.implicitHeight + 32
+                        orientation: Qt.Vertical
+                        maxRadius: 20
+                        color: Appearance.m3colors.m3surfaceContainerHigh
+                        visible: Config.ready && Config.options.statusBar && Config.options.statusBar.layoutStyle === "centered"
+                        RowLayout {
+                            id: centeredWidthRow
+                            anchors.fill: parent; anchors.margins: 16
+                            spacing: 16
+                            MaterialSymbol { text: "width_full"; iconSize: 24; color: Appearance.colors.colPrimary }
+                            StyledText { text: "Centered width"; Layout.fillWidth: true; color: Appearance.colors.colOnLayer1 }
+                            StyledSlider {
+                                Layout.preferredWidth: 160
+                                from: 800; to: 2000; stepSize: 50
+                                value: Config.ready && Config.options.statusBar ? (Config.options.statusBar.centeredWidth ?? 1200) : 1200
+                                onMoved: if (Config.ready && Config.options.statusBar)
+                                    Config.options.statusBar.centeredWidth = Math.round(value)
+                            }
+                            StyledText {
+                                text: Math.round(Config.ready && Config.options.statusBar
+                                    ? (Config.options.statusBar.centeredWidth ?? 1200) : 1200).toString() + "px"
+                                color: Appearance.colors.colOnLayer1
+                            }
+                        }
+                    }
     
                     // ── Corner Radius (only visible when background is active) ──
                     SegmentedWrapper {

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/ActiveWindowTitle.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/ActiveWindowTitle.qml
@@ -14,6 +14,9 @@ import Quickshell.Hyprland
 Item {
     id: root
     property HyprlandMonitor monitor
+    property color color: Appearance.colors.colStatusBarText
+    property color subtextColor: Appearance.colors.colStatusBarSubtext
+    
     readonly property Toplevel activeWindow: ToplevelManager.activeToplevel
     readonly property bool focusingThisMonitor: HyprlandData.activeWorkspace?.monitor == monitor?.name
 
@@ -45,7 +48,7 @@ Item {
             Layout.fillWidth: true
             Layout.maximumWidth: root.Layout.maximumWidth
             font.pixelSize: Appearance.font.pixelSize.smallest
-            color: Appearance.colors.colStatusBarSubtext
+            color: root.subtextColor
             elide: Text.ElideRight
             text: root.appClassText
         }
@@ -55,7 +58,7 @@ Item {
             Layout.fillWidth: true
             Layout.maximumWidth: root.Layout.maximumWidth
             font.pixelSize: Appearance.font.pixelSize.smaller
-            color: Appearance.colors.colStatusBarText
+            color: root.color
             elide: Text.ElideRight
             text: root.appTitleText
         }

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/BatteryIndicator.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/BatteryIndicator.qml
@@ -8,6 +8,8 @@ import Quickshell
 
 Item {
     id: root
+    property color color: Appearance.colors.colStatusBarText
+    
     readonly property var chargeState: Battery.chargeState
     readonly property bool isCharging: Battery.isCharging
     readonly property bool isPluggedIn: Battery.isPluggedIn
@@ -33,7 +35,7 @@ Item {
             // highlightColor: (isLow && !isCharging) ? Appearance.m3colors.m3error : Appearance.colors.colStatusBarText
             highlightColor: {
                  if (isLow && !isCharging) return Appearance.m3colors.m3error
-                 return Appearance.colors.colStatusBarText
+                 return root.color
             }
             trackColor: {
                 if (isLow && !isCharging) return Appearance.m3colors.m3errorContainer
@@ -60,14 +62,14 @@ Item {
                         text: "bolt"
                         iconSize: 8
                         visible: isCharging
-                        color: (isLow && !isCharging) ? Appearance.m3colors.m3onError : Appearance.colors.colStatusBarText
+                        color: (isLow && !isCharging) ? Appearance.m3colors.m3onError : root.color
                     }
                     StyledText {
                         Layout.alignment: Qt.AlignVCenter
                         font.pixelSize: 10
                         font.weight: Font.DemiBold
                         text: batteryProgress.text
-                        color: (isLow && !isCharging) ? Appearance.m3colors.m3onError : Appearance.colors.colStatusBarText
+                        color: (isLow && !isCharging) ? Appearance.m3colors.m3onError : root.color
                     }
                 }
             }

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/DynamicIsland.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/DynamicIsland.qml
@@ -31,7 +31,7 @@ Item {
 
     // --- State Logic ---
     property bool mediaShowing: false
-    Timer { id: mediaTimer; interval: 5000; onTriggered: root.mediaShowing = false }
+    Timer { id: mediaTimer; interval: 3000; onTriggered: root.mediaShowing = false }
 
     Connections {
         target: MprisController
@@ -66,6 +66,17 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         height: 28
         clip: true
+        
+        HoverHandler {
+            enabled: islandState === "media"
+            onHoveredChanged: {
+                if (hovered && Config.options.media.enableMediaHover) {
+                    GlobalStates.openMediaNotch(root.QsWindow.window.screen);
+                } else {
+                    GlobalStates.closeMediaNotchWithDelay();
+                }
+            }
+        }
         
         width: {
             if (islandState === "notification") {
@@ -256,6 +267,17 @@ Item {
         height: 28
         clip: true
         
+        HoverHandler {
+            enabled: islandState === "media"
+            onHoveredChanged: {
+                if (hovered && Config.options.media.enableMediaHover) {
+                    GlobalStates.openMediaNotch(root.QsWindow.window.screen);
+                } else {
+                    GlobalStates.closeMediaNotchWithDelay();
+                }
+            }
+        }
+        
         width: {
             if (islandState === "notification") return notifSummaryLabel.visible ? Math.min(notifSummaryLabel.implicitWidth, 200) + 8 : 0
             if (islandState === "recording") return recordTimeLabel.implicitWidth + 8
@@ -361,8 +383,13 @@ Item {
             acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
             
             onEntered: {
-                if (Config.options.media.enableMediaHover && (islandState === "media" || MprisController.activePlayer)) {
-                    GlobalStates.openMediaNotch(root.QsWindow.window.screen);
+                // Hovering the center reveal the island (state becomes "media")
+                // but we DON'T call openMediaNotch here.
+                if (MprisController.activePlayer) {
+                    root.mediaShowing = true;
+                    mediaTimer.restart();
+                    // Also stop the closing timer if it's already open from ear hover
+                    if (GlobalStates.mediaNotchOpen) GlobalStates.mediaNotchTimer.stop();
                 }
             }
             

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBar.qml
@@ -49,24 +49,23 @@ Scope {
             readonly property int cornerRadius: Config.ready && Config.options.statusBar
                 ? (Config.options.statusBar.backgroundCornerRadius ?? 20) : 20
 
-            property bool hasActiveWindows: false
-            readonly property bool showBackground: {
-                if (bgStyle === 1) return true;
-                if (bgStyle === 2) return hasActiveWindows;
-                return false;
+            // Track tiled windows for adaptive style
+            readonly property int activeWorkspaceId: Hyprland.monitorFor(modelData)?.activeWorkspace?.id ?? -1
+            
+            readonly property bool hasTiledWindows: {
+                if (bgStyle !== 2 || activeWorkspaceId === -1) return false;
+                // Filter windows that are on this monitor's active workspace and NOT floating
+                return HyprlandData.windowList.some(w => 
+                    w.workspace.id === activeWorkspaceId && 
+                    !w.floating && 
+                    w.monitor === monitorIndex
+                );
             }
 
-            // Track tiled windows for adaptive style
-            Connections {
-                enabled: barWindow.bgStyle === 2
-                target: HyprlandData
-                function onWindowListChanged() {
-                    const monitor = HyprlandData.monitors.find(m => m.id === barWindow.monitorIndex);
-                    const wsId = monitor?.activeWorkspace?.id;
-                    barWindow.hasActiveWindows = wsId
-                        ? HyprlandData.windowList.some(w => w.workspace.id === wsId && !w.floating)
-                        : false;
-                }
+            readonly property bool showBackground: {
+                if (bgStyle === 1) return true;
+                if (bgStyle === 2) return hasTiledWindows;
+                return false;
             }
 
             readonly property bool isCentered: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.layoutStyle === "centered" : false

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBar.qml
@@ -69,67 +69,69 @@ Scope {
                 }
             }
 
+            readonly property bool isCentered: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.layoutStyle === "centered" : false
+            readonly property real centeredWidth: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.centeredWidth : 1200
+
             // ── Solid background rectangle ─────────────────────────────
             Rectangle {
                 id: barBg
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    top: parent.top
-                }
-                height: Appearance.sizes.statusBarHeight
+                anchors.top: parent.top
+                anchors.topMargin: barWindow.isCentered && barWindow.showBackground ? -barWindow.cornerRadius : 0
+                anchors.horizontalCenter: parent.horizontalCenter
+                
+                width: barWindow.isCentered ? Math.min(barWindow.centeredWidth, parent.width - 40) : parent.width
+                height: Appearance.sizes.statusBarHeight + (barWindow.isCentered && barWindow.showBackground ? barWindow.cornerRadius : 0)
                 color: barWindow.showBackground ? Appearance.colors.colStatusBarSolid : "transparent"
+                
+                radius: barWindow.isCentered ? barWindow.cornerRadius : 0
 
-                Behavior on color {
-                    ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
-                }
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+                Behavior on width { NumberAnimation { duration: 400; easing.type: Easing.OutQuint } }
+                Behavior on anchors.topMargin { NumberAnimation { duration: 400; easing.type: Easing.OutQuint } }
             }
 
             // ── Gradient overlay (when not in background mode) ─────────
             Rectangle {
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    top: parent.top
-                }
-                height: Appearance.sizes.statusBarHeight
+                anchors.fill: barBg
                 color: "transparent"
+                radius: barBg.radius
+                visible: !barWindow.showBackground && (Config.ready && Config.options.statusBar ? Config.options.statusBar.useGradient : true)
                 gradient: Gradient {
                     GradientStop { position: 0.0; color: Appearance.colors.colStatusBarGradientStart }
                     GradientStop { position: 1.0; color: Appearance.colors.colStatusBarGradientEnd }
                 }
             }
 
-            // ── Bottom-left round corner decorator ─────────────────────
+            // ── Left Round Corner Decorator ─────────────────────
             RoundCorner {
                 anchors {
-                    left: parent.left
-                    top: barBg.bottom
+                    left: barWindow.isCentered ? barBg.right : parent.left
+                    top: barWindow.isCentered ? parent.top : barBg.bottom
                 }
                 implicitSize: barWindow.cornerRadius
                 color: barWindow.showBackground ? Appearance.colors.colStatusBarSolid : "transparent"
-                corner: RoundCorner.CornerEnum.TopLeft
+                // Standard mode: Bottom-left corner (inverted)
+                // Centered mode: Top-left corner (inverted, adjacent to pill right side)
+                corner: barWindow.isCentered ? RoundCorner.CornerEnum.TopLeft : RoundCorner.CornerEnum.TopLeft
                 visible: barWindow.showBackground
 
-                Behavior on color {
-                    ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
-                }
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
             }
 
-            // ── Bottom-right round corner decorator ────────────────────
+            // ── Right Round Corner Decorator ────────────────────
             RoundCorner {
                 anchors {
-                    right: parent.right
-                    top: barBg.bottom
+                    right: barWindow.isCentered ? barBg.left : parent.right
+                    top: barWindow.isCentered ? parent.top : barBg.bottom
                 }
                 implicitSize: barWindow.cornerRadius
                 color: barWindow.showBackground ? Appearance.colors.colStatusBarSolid : "transparent"
-                corner: RoundCorner.CornerEnum.TopRight
+                // Standard mode: Bottom-right corner (inverted)
+                // Centered mode: Top-right corner (inverted, adjacent to pill left side)
+                corner: barWindow.isCentered ? RoundCorner.CornerEnum.TopRight : RoundCorner.CornerEnum.TopRight
                 visible: barWindow.showBackground
 
-                Behavior on color {
-                    ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
-                }
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
             }
 
             // ── Content ────────────────────────────────────────────────

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBar.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBar.qml
@@ -79,22 +79,26 @@ Scope {
                 anchors.topMargin: barWindow.isCentered && barWindow.showBackground ? -barWindow.cornerRadius : 0
                 anchors.horizontalCenter: parent.horizontalCenter
                 
-                width: barWindow.isCentered ? Math.min(barWindow.centeredWidth, parent.width - 40) : parent.width
+                width: (barWindow.isCentered && barWindow.showBackground) ? Math.min(barWindow.centeredWidth, parent.width - 40) : parent.width
                 height: Appearance.sizes.statusBarHeight + (barWindow.isCentered && barWindow.showBackground ? barWindow.cornerRadius : 0)
                 color: barWindow.showBackground ? Appearance.colors.colStatusBarSolid : "transparent"
                 
-                radius: barWindow.isCentered ? barWindow.cornerRadius : 0
+                radius: (barWindow.isCentered && barWindow.showBackground) ? barWindow.cornerRadius : 0
 
                 Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
                 Behavior on width { NumberAnimation { duration: 400; easing.type: Easing.OutQuint } }
                 Behavior on anchors.topMargin { NumberAnimation { duration: 400; easing.type: Easing.OutQuint } }
             }
 
-            // ── Gradient overlay (when not in background mode) ─────────
+            // ── Gradient overlay (Always full width) ─────────
             Rectangle {
-                anchors.fill: barBg
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    top: parent.top
+                }
+                height: Appearance.sizes.statusBarHeight
                 color: "transparent"
-                radius: barBg.radius
                 visible: !barWindow.showBackground && (Config.ready && Config.options.statusBar ? Config.options.statusBar.useGradient : true)
                 gradient: Gradient {
                     GradientStop { position: 0.0; color: Appearance.colors.colStatusBarGradientStart }

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
@@ -23,6 +23,23 @@ Item {
     
     readonly property real sidePadding: isCentered ? Math.max(12, (root.width - centeredWidth) / 2) : 12
 
+    // Dynamic background detection for color switching
+    readonly property int bgStyle: (Config.ready && Config.options.statusBar) ? (Config.options.statusBar.backgroundStyle ?? 0) : 0
+    readonly property int activeWorkspaceId: monitor?.activeWorkspace?.id ?? -1
+    readonly property bool hasTiledWindows: {
+        if (bgStyle !== 2 || activeWorkspaceId === -1) return false;
+        return HyprlandData.windowList.some(w => 
+            w.workspace.id === activeWorkspaceId && 
+            !w.floating && 
+            w.monitor === monitorIndex
+        );
+    }
+    readonly property bool showBackground: bgStyle === 1 || (bgStyle === 2 && hasTiledWindows)
+
+    // Selection of the final color based on actual visibility
+    readonly property color finalContentColor: showBackground ? Appearance.m3colors.m3onSurface : Appearance.colors.colStatusBarText
+    readonly property color finalSubtextColor: showBackground ? Appearance.m3colors.m3onSurfaceVariant : Appearance.colors.colStatusBarSubtext
+
     // ── Click-to-close backdrop (invisible, catches unfocused clicks) ──
     MouseArea {
         anchors.fill: parent
@@ -126,7 +143,7 @@ Item {
                         return (custom && custom !== "") ? custom : (SystemInfo.distroIcon || "linux-symbolic");
                     }
                     colorize: true
-                    color: Appearance.colors.colStatusBarText
+                    color: root.finalContentColor
                     width: (root.monitor && root.monitor.width && root.monitor.width > 2000) ? 20 : 18
                     height: (root.monitor && root.monitor.width && root.monitor.width > 2000) ? 20 : 18
                     Layout.alignment: Qt.AlignVCenter
@@ -140,6 +157,8 @@ Item {
                     Layout.alignment: Qt.AlignVCenter
                     Layout.maximumWidth: Math.min(400, (root.monitor ? root.monitor.width : 1920) * 0.25)
                     monitor: root.monitor
+                    color: root.finalContentColor
+                    subtextColor: root.finalSubtextColor
                 }
             }
         }
@@ -160,7 +179,7 @@ Item {
         text: DateTime.currentTime
         font.pixelSize: 14 // Bigger font
         font.weight: Font.DemiBold
-        color: Appearance.colors.colStatusBarText
+        color: root.finalContentColor
     }
 
     // Date (Right of Notch)
@@ -170,7 +189,7 @@ Item {
         text: DateTime.currentDate
         font.pixelSize: 14 // Bigger font
         font.weight: Font.DemiBold
-        color: Appearance.colors.colStatusBarText
+        color: root.finalContentColor
     }
 
     // --- Absolute Center Workspace Indicator ---
@@ -198,6 +217,8 @@ Item {
             // Network Speed Meter
             NetworkSpeedMeter {
                 Layout.alignment: Qt.AlignVCenter
+                color: root.finalContentColor
+                subtextColor: root.finalSubtextColor
             }
 
             // System Tray (Apps tray will be to the left of this)
@@ -212,7 +233,7 @@ Item {
                 text: "key"
                 iconSize: 16
                 fill: 1
-                color: Appearance.colors.colStatusBarText
+                color: root.finalContentColor
             }
 
             // WiFi (real data from Network service)
@@ -220,7 +241,7 @@ Item {
                 text: Network.materialSymbol
                 iconSize: 16
                 fill: 1
-                color: Appearance.colors.colStatusBarText
+                color: root.finalContentColor
             }
 
             // Bluetooth (real data from BluetoothStatus service)
@@ -231,7 +252,7 @@ Item {
                     text: BluetoothStatus.materialSymbol
                     iconSize: 16
                     fill: BluetoothStatus.connected ? 1 : 0
-                    color: Appearance.colors.colStatusBarText
+                    color: root.finalContentColor
                 }
 
                 // Vertical Battery Bar
@@ -241,7 +262,7 @@ Item {
                     width: 3
                     height: 12
                     radius: 1.5
-                    color: Appearance.colors.colStatusBarSubtext
+                    color: root.finalSubtextColor
                     Layout.alignment: Qt.AlignVCenter
                     
                     Rectangle {
@@ -249,7 +270,7 @@ Item {
                         width: parent.width
                         height: parent.height * (parent.device ? parent.device.battery : 0)
                         radius: 1.5
-                        color: Appearance.colors.colStatusBarText
+                        color: root.finalContentColor
                     }
                 }
             }
@@ -258,6 +279,7 @@ Item {
             BatteryIndicator {
                 visible: Battery.available
                 Layout.alignment: Qt.AlignVCenter
+                color: root.finalContentColor
             }
 
 
@@ -275,7 +297,7 @@ Item {
                     text: "notifications_active"
                     iconSize: 16
                     fill: 1
-                    color: Appearance.colors.colStatusBarText
+                    color: root.finalContentColor
                 }
 
                 Rectangle {
@@ -306,7 +328,7 @@ Item {
                 text: "notifications_paused"
                 iconSize: 16
                 fill: 1
-                color: Appearance.colors.colStatusBarText
+                color: root.finalContentColor
                 Layout.alignment: Qt.AlignVCenter
             }
 

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
@@ -157,7 +157,8 @@ Item {
                 // Active window title
                 ActiveWindowTitle {
                     Layout.alignment: Qt.AlignVCenter
-                    Layout.maximumWidth: Math.min(400, (root.monitor ? root.monitor.width : 1920) * 0.25)
+                    // Dynamically calculate max width: proportional to HUD width in centered mode
+                    Layout.maximumWidth: root.isCentered ? (root.centeredWidth * 0.2) : Math.min(400, parent.width * 0.25)
                     monitor: root.monitor
                     color: root.finalContentColor
                     subtextColor: root.finalSubtextColor

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
@@ -52,7 +52,7 @@ Item {
             tooltipText: "Scroll to change brightness"
             side: "left"
             anchors.left: parent.left
-            anchors.leftMargin: root.sidePadding
+            anchors.leftMargin: root.isCentered ? root.sidePadding : 4
             anchors.verticalCenter: parent.verticalCenter
         }
     }
@@ -79,7 +79,7 @@ Item {
             tooltipText: "Scroll to change volume"
             side: "right"
             anchors.right: parent.right
-            anchors.rightMargin: root.sidePadding
+            anchors.rightMargin: root.isCentered ? root.sidePadding : 4
             anchors.verticalCenter: parent.verticalCenter
         }
     }

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
@@ -18,6 +18,11 @@ Item {
     property int monitorIndex: 0
     readonly property HyprlandMonitor monitor: Hyprland.monitorFor(root.QsWindow.window ? root.QsWindow.window.screen : null)
 
+    readonly property bool isCentered: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.layoutStyle === "centered" : false
+    readonly property real centeredWidth: (Config.ready && Config.options.statusBar) ? Config.options.statusBar.centeredWidth : 1200
+    
+    readonly property real sidePadding: isCentered ? Math.max(12, (root.width - centeredWidth) / 2) : 12
+
     // ── Click-to-close backdrop (invisible, catches unfocused clicks) ──
     MouseArea {
         anchors.fill: parent
@@ -47,6 +52,7 @@ Item {
             tooltipText: "Scroll to change brightness"
             side: "left"
             anchors.left: parent.left
+            anchors.leftMargin: root.sidePadding
             anchors.verticalCenter: parent.verticalCenter
         }
     }
@@ -73,6 +79,7 @@ Item {
             tooltipText: "Scroll to change volume"
             side: "right"
             anchors.right: parent.right
+            anchors.rightMargin: root.sidePadding
             anchors.verticalCenter: parent.verticalCenter
         }
     }
@@ -98,7 +105,7 @@ Item {
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.bottom: parent.bottom
-        anchors.leftMargin: 12
+        anchors.leftMargin: root.sidePadding + (root.isCentered ? 12 : 0)
         spacing: 8
 
         Item {
@@ -312,7 +319,7 @@ Item {
     PrivacyIndicator {
         id: privacyIndicator
         anchors.right: parent.right
-        anchors.rightMargin: 8
+        anchors.rightMargin: root.sidePadding + (root.isCentered ? 8 : -4)
         anchors.verticalCenter: parent.verticalCenter
     }
 }

--- a/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
+++ b/dotfiles/.config/quickshell/nandoroid/panels/StatusBar/StatusBarContent.qml
@@ -71,6 +71,7 @@ Item {
             anchors.left: parent.left
             anchors.leftMargin: root.isCentered ? root.sidePadding : 4
             anchors.verticalCenter: parent.verticalCenter
+            color: root.finalContentColor
         }
     }
 
@@ -98,6 +99,7 @@ Item {
             anchors.right: parent.right
             anchors.rightMargin: root.isCentered ? root.sidePadding : 4
             anchors.verticalCenter: parent.verticalCenter
+            color: root.finalContentColor
         }
     }
 

--- a/dotfiles/.config/quickshell/nandoroid/widgets/NandoClock.qml
+++ b/dotfiles/.config/quickshell/nandoroid/widgets/NandoClock.qml
@@ -39,7 +39,7 @@ Item {
     readonly property real clockOffsetY: Config.ready ? Config.options.appearance.clock.offsetY : -50
 
     // Dynamic anchor point based on alignment to prevent shifting
-    readonly property string alignment: {
+    property string alignment: {
         if (!loader.item) return "center";
         if (loader.item.alignment !== undefined) return loader.item.alignment;
         if (loader.item.cfg && loader.item.cfg.alignment !== undefined) return loader.item.cfg.alignment;
@@ -47,12 +47,13 @@ Item {
     }
 
     // Position the Item's (0,0) at the anchor target (Center + Offset)
-    x: (parentWidth / 2) + (isLockscreen ? 0 : clockOffsetX)
-    y: (parentHeight / 2 - height / 2) + (isLockscreen ? -50 : clockOffsetY)
+    x: isLockscreen ? x : (parentWidth / 2) + clockOffsetX
+    y: isLockscreen ? y : (parentHeight / 2 - height / 2) + clockOffsetY
     
     // Shift the item relative to its width based on alignment
     transform: Translate {
         x: {
+            if (root.isLockscreen) return 0; // Fixed center on lockscreen
             if (root.alignment === "left") return 0; // Anchor is at X (Left edge)
             if (root.alignment === "right") return -root.width; // Anchor is at X (Right edge)
             return -root.width / 2; // Anchor is at X (Center)

--- a/dotfiles/.config/quickshell/nandoroid/widgets/NetworkSpeedMeter.qml
+++ b/dotfiles/.config/quickshell/nandoroid/widgets/NetworkSpeedMeter.qml
@@ -12,6 +12,9 @@ ColumnLayout {
     spacing: -6
     visible: Config.ready && Config.options.bar ? Config.options.bar.show_network_speed : false
 
+    property color color: Appearance.colors.colStatusBarText
+    property color subtextColor: Appearance.colors.colStatusBarSubtext
+
     readonly property string currentUnit: Config.ready && Config.options.bar ? Config.options.bar.network_speed_unit : "KB"
 
     function formatSpeed(bytes) {
@@ -47,14 +50,14 @@ ColumnLayout {
             text: root.formatSpeed(SystemData.networkTxRate)
             font.pixelSize: 10
             font.weight: Font.Medium
-            color: Appearance.colors.colStatusBarText
+            color: root.color
             horizontalAlignment: Text.AlignRight
             verticalAlignment: Text.AlignBottom
         }
         MaterialSymbol {
             text: "arrow_drop_up"
             iconSize: 14
-            color: root.isHighSpeed(SystemData.networkTxRate) ? Appearance.colors.colStatusBarText : Appearance.colors.colStatusBarSubtext
+            color: root.isHighSpeed(SystemData.networkTxRate) ? root.color : root.subtextColor
         }
     }
 
@@ -67,14 +70,14 @@ ColumnLayout {
             text: root.formatSpeed(SystemData.networkRxRate)
             font.pixelSize: 10
             font.weight: Font.Medium
-            color: Appearance.colors.colStatusBarText
+            color: root.color
             horizontalAlignment: Text.AlignRight
             verticalAlignment: Text.AlignTop
         }
         MaterialSymbol {
             text: "arrow_drop_down"
             iconSize: 14
-            color: root.isHighSpeed(SystemData.networkRxRate) ? Appearance.colors.colStatusBarText : Appearance.colors.colStatusBarSubtext
+            color: root.isHighSpeed(SystemData.networkRxRate) ? root.color : root.subtextColor
         }
     }
 }


### PR DESCRIPTION
# PR: Centered HUD Mode and True Adaptive Logic

## Overview
This branch implements a new Centered HUD (Pill mode) for the Status Bar, optimized for large or ultrawide monitors. It also refines the adaptive logic to ensure text and icon colors are perfectly synced with the background state.

## Key Changes

### 1. Centered HUD (Pill Mode)
- Status bar background can now shrink into a centered Pill (adjustable width).
- Smooth width morphing animation when switching between modes.
- Side panels (Quick Settings & Notification Center) now align their margins with the HUD edges.
- Vertical animations: side panels slide down from the top in HUD mode for a cohesive look.
- Lockscreen status bar now supports HUD mode for visual parity.

### 2. True Adaptive System
- Dynamic Component Coloring: text, battery icon, network speed, and window titles now switch between Adaptive and Surface colors based on real-time solid background visibility.
- Refined window detection logic to prevent "ghost" backgrounds on empty workspaces.
- Main top gradient remains edge-to-edge even in HUD mode to maintain top-screen aesthetics.

### 3. Dynamic Island Tweaks
- Hover triggers for the media popup (notch) are now restricted to the "Ears" (Icon/Artist/Title) to avoid accidental triggers while switching workspaces.
- Independent Timers: media info display persists for 3s, while the popup persists for 2s (snappier feel).
- Faster expansion: ear reveal animation reduced to 150ms for better responsiveness.

### 4. Settings UI Refinement
- Aligned the slider and label layout in the Status Bar settings page.
- Corner radius is now capped at 20px to prevent visual bugs in Centered mode.

---